### PR TITLE
Fix check for last episode in Aniwatch nextEpUrl function

### DIFF
--- a/src/pages/Aniwatch/main.ts
+++ b/src/pages/Aniwatch/main.ts
@@ -47,7 +47,7 @@ export const Aniwatch: pageInterface = {
       );
     },
     nextEpUrl(url) {
-      if (tabPage !== 'stream' || !j.$('#anilyr-nextEpi').is('[disabled=disabled]')) return '';
+      if (tabPage !== 'stream' || j.$('#anilyr-nextEpi').is('[disabled=disabled]')) return '';
 
       const urlPart5 = utils.urlPart(url, 5);
 


### PR DESCRIPTION
Just needed to get rid of a single ! in nextEpUrl to correctly determine whether we are on the last episode. Closes #443.