### PR TITLE
[FIX] AnimeZone iframe fix

### DIFF
--- a/src/pages/AnimeZone/main.ts
+++ b/src/pages/AnimeZone/main.ts
@@ -99,7 +99,7 @@ export const AnimeZone: pageInterface = {
           iframe.height = '100%';
 
           iframe.setAttribute('allowfullscreen', 'true');
-          embedContainer.append(j.html(iframe));
+          embedContainer.append(iframe);
           observer.disconnect();
         }
       };


### PR DESCRIPTION
`j.html` as parameter accepts string, which does not work, because `iframe` variable is actually object.