### PR TITLE
[TASK] Chnage animesuge TLD from .io to .to

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Makes it possible to use your MyAnimeList/Anilist/Kitsu/Simkl anime/mangalist as
                 <td><a href="https://dynasty-scans.com"><img src="https://favicon.malsync.moe/?domain=https://dynasty-scans.com"> DynastyScans</a></td>
                 <td></td>
               </tr><tr>
-                <td><a href="https://animesuge.io"><img src="https://favicon.malsync.moe/?domain=https://animesuge.io"> AnimeSuge</a></td>
+                <td><a href="https://animesuge.to"><img src="https://favicon.malsync.moe/?domain=https://animesuge.to"> AnimeSuge</a></td>
                 <td><a href="https://sugarbscan.com/"><img src="https://favicon.malsync.moe/?domain=https://sugarbscan.com/"> SugarBabies</a></td>
                 <td></td>
               </tr><tr>

--- a/pages.md
+++ b/pages.md
@@ -1,4 +1,3 @@
-
   <h1>Anime</h1>
   <table>
     <thead>
@@ -174,7 +173,7 @@
     <td>:x:</td>
     <td>:x:</td>
   </tr><tr>
-    <td><a href="https://animesuge.io"><img src="https://favicon.malsync.moe/?domain=https://animesuge.io"> AnimeSuge</a></td>
+    <td><a href="https://animesuge.to"><img src="https://favicon.malsync.moe/?domain=https://animesuge.to"> AnimeSuge</a></td>
     <td>English</td>
     <td>:heavy_check_mark:</td>
     <td>:heavy_check_mark:</td>
@@ -1018,4 +1017,3 @@
   </tr>
     </tbody>
   </table>
-  

--- a/src/pages/AnimeSuge/tests.json
+++ b/src/pages/AnimeSuge/tests.json
@@ -1,19 +1,19 @@
 {
   "title": "AnimeSuge",
-  "url": "https://animesuge.io/",
+  "url": "https://animesuge.to/",
   "testCases": [
     {
-      "url": "https://animesuge.io/anime/no-game-no-life-4qkm/ep-4",
+      "url": "https://animesuge.to/anime/no-game-no-life-4qkm/ep-4",
       "expected": {
         "sync": true,
         "title": "No Game No Life",
         "identifier": "4qkm",
-        "overviewUrl": "https://animesuge.io/anime/no-game-no-life-4qkm/ep-1",
-        "nextEpUrl": "https://animesuge.io/anime/no-game-no-life-4qkm/ep-5",
+        "overviewUrl": "https://animesuge.to/anime/no-game-no-life-4qkm/ep-1",
+        "nextEpUrl": "https://animesuge.to/anime/no-game-no-life-4qkm/ep-5",
         "episode": 4,
         "uiSelector": true,
         "epList": {
-          "5": "https://animesuge.io/anime/no-game-no-life-4qkm/ep-5"
+          "5": "https://animesuge.to/anime/no-game-no-life-4qkm/ep-5"
         }
       }
     }

--- a/src/pages/list.json
+++ b/src/pages/list.json
@@ -535,7 +535,7 @@
     "name": "AnimeWho"
   },
   {
-    "domain": "https://animesuge.io",
+    "domain": "https://animesuge.to",
     "type": "anime",
     "name": "AnimeSuge"
   },


### PR DESCRIPTION
The owner of animesuge has switched domains from [animesuge.io](https://animesuge.io) to [animesuge.to](https://animesuge.to), and this made MALSync stop working.
These changes should fix the above mentioned issue