### PR TITLE
animepahe: Fix overview page UI overlap

### DIFF
--- a/src/pages/animepahe/main.ts
+++ b/src/pages/animepahe/main.ts
@@ -49,7 +49,7 @@ export const animepahe: pageInterface = {
       return getId();
     },
     uiSelector(selector) {
-      j.$('.anime-detail').after(j.html(selector));
+      j.$('.anime-content').prepend(j.html(selector));
     },
     getMalUrl(provider) {
       let url = j

--- a/src/pages/animepahe/style.less
+++ b/src/pages/animepahe/style.less
@@ -37,3 +37,9 @@ section.main .content-wrapper .theatre .theatre-info {
   /* same as .tab-content */
   margin-left: 235px;
 }
+@media (max-width: 767px) {
+  .anime-content #malp {
+    margin-left: 0;
+    padding: 0 15px;
+  }
+}

--- a/src/pages/animepahe/style.less
+++ b/src/pages/animepahe/style.less
@@ -32,3 +32,8 @@ section.main .content-wrapper .theatre .theatre-info {
   background-color: #002966;
   background-color: #002966ba;
 }
+
+.anime-content #malp {
+    /* same as .tab-content */
+    margin-left: 235px;
+}

--- a/src/pages/animepahe/style.less
+++ b/src/pages/animepahe/style.less
@@ -37,6 +37,7 @@ section.main .content-wrapper .theatre .theatre-info {
   /* same as .tab-content */
   margin-left: 235px;
 }
+
 @media (max-width: 767px) {
   .anime-content #malp {
     margin-left: 0;

--- a/src/pages/animepahe/style.less
+++ b/src/pages/animepahe/style.less
@@ -34,6 +34,6 @@ section.main .content-wrapper .theatre .theatre-info {
 }
 
 .anime-content #malp {
-    /* same as .tab-content */
-    margin-left: 235px;
+  /* same as .tab-content */
+  margin-left: 235px;
 }


### PR DESCRIPTION
Fixed UI on animepahe overview page so it's no longer partially hidden by the anime cover image on the Relations and Recommendations tabs. Moved to top for consistency between tabs.
| Before | After |
| --- | --- |
| ![summary before](https://user-images.githubusercontent.com/7268094/147994512-40dc77b8-841a-4a1a-b85d-5e633d2d56cb.png) | ![summary after](https://user-images.githubusercontent.com/7268094/147994510-537b849e-f3b3-4c2d-a60e-a3a9178a4564.png) |
| ![relations before](https://user-images.githubusercontent.com/7268094/147994509-286508e8-b83c-4588-9b2c-dd0b29127b3c.png) | ![relations after](https://user-images.githubusercontent.com/7268094/147994513-7a4ff21d-f237-434f-b992-f3c78a6e4426.png) |