### PR TITLE
Fixed bug regarding manga volumes in discord rich presence

### DIFF
--- a/src/pages/syncPage.ts
+++ b/src/pages/syncPage.ts
@@ -1194,16 +1194,20 @@ export class SyncPage {
             }
           }
           if (typeof this.curState.episode !== 'undefined') {
-            let totalEp;
-            if (this.curState.volume > 0){
-              const ep = this.curState.volume;
-              totalEp = this.singleObj.getTotalVolumes();
-              if (!totalEp) totalEp = '?';
-              pres.presence.state = `${api.storage.lang('UI_Volume')} ${ep} of ${totalEp}`;
-            }
-            else{
+            if (this.curState.volume > 0) {
+              const vol = this.curState.volume;
+              let totalVol = this.singleObj.getTotalVolumes();
+              if (!totalVol) totalVol = '?';
+              if (this.curState.episode > 0) {
+                let totalEp = this.singleObj.getTotalEpisodes();
+                pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol}/${totalVol}`;
+                pres.presence.state += ` | ${utils.episode(this.page.type)} ${this.curState.episode}/${totalEp}`;
+              } else {
+                pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol} of ${totalVol}`;
+              }
+            } else {
               const ep = this.curState.episode;
-              totalEp = this.singleObj.getTotalEpisodes();
+              let totalEp = this.singleObj.getTotalEpisodes();
               if (!totalEp) totalEp = '?';
               pres.presence.state = `${utils.episode(this.page.type)} ${ep} of ${totalEp}`;
             }

--- a/src/pages/syncPage.ts
+++ b/src/pages/syncPage.ts
@@ -1194,24 +1194,22 @@ export class SyncPage {
             }
           }
           if (typeof this.curState.episode !== 'undefined') {
+            const stateParts: string[] = [];
+
+            if (this.curState.episode > 0) {
+              let totalEp = this.singleObj.getTotalEpisodes();
+              totalEp = totalEp ? `/${totalEp}` : '';
+              stateParts.push(`${utils.episode(this.page.type)} ${this.curState.episode}${totalEp}`);
+            }
+
             if (this.curState.volume > 0) {
               const vol = this.curState.volume;
               let totalVol = this.singleObj.getTotalVolumes();
-              if (!totalVol) totalVol = '?';
-              if (this.curState.episode > 0) {
-                let totalEp = this.singleObj.getTotalEpisodes();
-                if (!totalEp) totalEp = '?';
-                pres.presence.state = `${utils.episode(this.page.type)} ${this.curState.episode}/${totalEp}`;
-                pres.presence.state += ` | ${api.storage.lang('UI_Volume')} ${vol}/${totalVol}`;
-              } else {
-                pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol} of ${totalVol}`;
-              }
-            } else {
-              const ep = this.curState.episode;
-              let totalEp = this.singleObj.getTotalEpisodes();
-              if (!totalEp) totalEp = '?';
-              pres.presence.state = `${utils.episode(this.page.type)} ${ep} of ${totalEp}`;
+              totalVol = totalVol ? `/${totalVol}` : '';
+              stateParts.push(`${api.storage.lang('UI_Volume')} ${vol}${totalVol}`);
             }
+
+            pres.presence.state = stateParts.join(' | ');
 
             if (typeof this.curState.lastVideoTime !== 'undefined') {
               if (this.curState.lastVideoTime.paused) {

--- a/src/pages/syncPage.ts
+++ b/src/pages/syncPage.ts
@@ -1194,11 +1194,19 @@ export class SyncPage {
             }
           }
           if (typeof this.curState.episode !== 'undefined') {
-            const ep = this.curState.episode;
-            let totalEp = this.singleObj.getTotalEpisodes();
-            if (!totalEp) totalEp = '?';
-
-            pres.presence.state = `${utils.episode(this.page.type)} ${ep} of ${totalEp}`;
+            let totalEp;
+            if (this.curState.volume > 0){
+              const ep = this.curState.volume;
+              totalEp = this.singleObj.getTotalVolumes();
+              if (!totalEp) totalEp = '?';
+              pres.presence.state = `${api.storage.lang('UI_Volume')} ${ep} of ${totalEp}`;
+            }
+            else{
+              const ep = this.curState.episode;
+              totalEp = this.singleObj.getTotalEpisodes();
+              if (!totalEp) totalEp = '?';
+              pres.presence.state = `${utils.episode(this.page.type)} ${ep} of ${totalEp}`;
+            }
 
             if (typeof this.curState.lastVideoTime !== 'undefined') {
               if (this.curState.lastVideoTime.paused) {

--- a/src/pages/syncPage.ts
+++ b/src/pages/syncPage.ts
@@ -1201,8 +1201,8 @@ export class SyncPage {
               if (this.curState.episode > 0) {
                 let totalEp = this.singleObj.getTotalEpisodes();
                 if (!totalEp) totalEp = '?';
-                pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol}/${totalVol}`;
-                pres.presence.state += ` | ${utils.episode(this.page.type)} ${this.curState.episode}/${totalEp}`;
+                pres.presence.state = `${utils.episode(this.page.type)} ${this.curState.episode}/${totalEp}`;
+                pres.presence.state += ` | ${api.storage.lang('UI_Volume')} ${vol}/${totalVol}`;
               } else {
                 pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol} of ${totalVol}`;
               }

--- a/src/pages/syncPage.ts
+++ b/src/pages/syncPage.ts
@@ -1200,6 +1200,7 @@ export class SyncPage {
               if (!totalVol) totalVol = '?';
               if (this.curState.episode > 0) {
                 let totalEp = this.singleObj.getTotalEpisodes();
+                if (!totalEp) totalEp = '?';
                 pres.presence.state = `${api.storage.lang('UI_Volume')} ${vol}/${totalVol}`;
                 pres.presence.state += ` | ${utils.episode(this.page.type)} ${this.curState.episode}/${totalEp}`;
               } else {


### PR DESCRIPTION
I found a bug regarding the rich presence. 

I was testing the extension with Komga and found out that if the manga has "volume" or "volumes" tag, the rich presence will display "Chapter: 0 of X".

![image](https://user-images.githubusercontent.com/30806751/148722297-adf1063c-5a87-4466-ad04-68040715727f.png)

Checking for the volumes fixes the issue. I also called the "UI_Volume" directly.

![image](https://user-images.githubusercontent.com/30806751/148722399-f92ff2c6-0c9d-43a0-b30b-d243eb035523.png)

