### PR TITLE
Fix Cubari proxy chapter recognition

### DIFF
--- a/src/pages/Cubari/main.ts
+++ b/src/pages/Cubari/main.ts
@@ -41,14 +41,17 @@ export const Cubari: pageInterface = {
       );
     },
     getEpisode(url) {
-      let temp = j
-        .$(
-          '#rdr-main > aside > div.rdr-aside-content > section.rdr-selector > div.rdr-selector-mid > div.rdr-chap-wrap.UI.FauxDrop > label',
-        )
-        .text();
-      temp = temp.substring(temp.indexOf('-') + 2).split('.')[0];
-      if (!temp || !temp.length) return 0;
-      return Number(temp.replace(/\D+/g, ''));
+      if (url.split('/')[4] === 'mangasee') {
+        let temp = j
+          .$(
+            '#rdr-main > aside > div.rdr-aside-content > section.rdr-selector > div.rdr-selector-mid > div.rdr-chap-wrap.UI.FauxDrop > label',
+          )
+          .text();
+        temp = temp.substring(temp.indexOf('-') + 2).split('.')[0];
+        if (!temp || !temp.length) return 0;
+        return Number(temp.replace(/\D+/g, ''));
+      }
+      return parseInt(utils.urlPart(url, 6));
     },
   },
   overview: {

--- a/src/pages/Cubari/main.ts
+++ b/src/pages/Cubari/main.ts
@@ -1,0 +1,127 @@
+import { pageInterface } from '../pageInterface';
+
+const excluded = ['imgur'];
+
+export const Cubari: pageInterface = {
+  name: 'Cubari',
+  domain: ['https://cubari.moe'],
+  languages: ['English'],
+  type: 'manga',
+  isSyncPage(url) {
+    if (
+      url.split('/')[3] === 'read' &&
+      !excluded.includes(url.split('/')[4]) &&
+      url.split('/').length >= 8
+    ) {
+      return true;
+    }
+    return false;
+  },
+  isOverviewPage(url) {
+    if (
+      url.split('/')[3] === 'read' &&
+      !excluded.includes(url.split('/')[4]) &&
+      url.split('/').length >= 6
+    ) {
+      return true;
+    }
+    return false;
+  },
+  sync: {
+    getTitle(url) {
+      return j.$('#rdr-main > aside > header > h1 > a').text();
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 5);
+    },
+    getOverviewUrl(url) {
+      return utils.absoluteLink(
+        j.$('#rdr-main > aside > header > h1 > a').attr('href'),
+        Cubari.domain,
+      );
+    },
+    getEpisode(url) {
+      let temp = j
+        .$(
+          '#rdr-main > aside > div.rdr-aside-content > section.rdr-selector > div.rdr-selector-mid > div.rdr-chap-wrap.UI.FauxDrop > label',
+        )
+        .text();
+      temp = temp.substring(temp.indexOf('-') + 2).split('.')[0];
+      if (!temp || !temp.length) return 0;
+      return Number(temp.replace(/\D+/g, ''));
+    },
+  },
+  overview: {
+    getTitle(url) {
+      return j.$('div.series-content > article > h1, article content > h1').first().text();
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 5);
+    },
+    uiSelector(selector) {
+      j.$('div.series-content > article').after(j.html(selector));
+    },
+    list: {
+      offsetHandler: false,
+      elementsSelector() {
+        return j
+          .$('div#detailedView, div#compactView, tbody#chapterTable')
+          .not('.d-none')
+          .first()
+          .find(`a[href*="/read/${utils.urlPart(window.location.href, 4)}"]`);
+      },
+      elementUrl(selector) {
+        return utils.absoluteLink(selector.attr('href') || '', Cubari.domain);
+      },
+      elementEp(selector) {
+        return Cubari.sync.getEpisode(Cubari.overview!.list!.elementUrl!(selector));
+      },
+    },
+  },
+  init(page) {
+    api.storage.addStyle(
+      require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
+    );
+    let interval;
+
+    let urlWithoutPage = '';
+
+    utils.fullUrlChangeDetect(function () {
+      page.reset();
+      clearInterval(interval);
+      interval = utils.waitUntilTrue(
+        function () {
+          if (
+            Cubari.overview!.getTitle(window.location.href).length ||
+            Cubari.sync.getTitle(window.location.href).length
+          ) {
+            return true;
+          }
+          return false;
+        },
+        function () {
+          if (window.location.href.split('/').slice(0, 7).join('/') !== urlWithoutPage) {
+            urlWithoutPage = window.location.href.split('/').slice(0, 7).join('/');
+
+            switch (window.location.href.split('/')[4]) {
+              case 'mangadex':
+                Cubari.database = 'Mangadex';
+                break;
+              case 'mangasee':
+                Cubari.database = 'MangaSee';
+                break;
+              default:
+                Cubari.database = undefined;
+                break;
+            }
+            page.handlePage();
+          }
+        },
+      );
+    });
+
+    j.$(document).on('click', 'div.series-content > div.btn-group', () => {
+      page.handleList();
+    });
+  },
+};

--- a/src/pages/Cubari/meta.json
+++ b/src/pages/Cubari/meta.json
@@ -1,0 +1,5 @@
+{
+  "urls": {
+    "match": ["*://cubari.moe/*"]
+  }
+}

--- a/src/pages/Cubari/style.less
+++ b/src/pages/Cubari/style.less
@@ -1,0 +1,16 @@
+@import './../pages';
+
+@textColor: white !important;
+
+#malp {
+  padding: 1em 1.3em;
+}
+.open-info-popup.floatbutton {
+  bottom: 100px !important;
+}
+
+.mal-sync-active {
+  background-color: transparent;
+  border-left: 5px solid #002966;
+  padding-left: 5px;
+}

--- a/src/pages/Cubari/tests.json
+++ b/src/pages/Cubari/tests.json
@@ -1,0 +1,30 @@
+{
+  "title": "Cubari",
+  "url": "https://cubari.moe",
+  "testCases": [
+    {
+      "url": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/",
+      "expected": {
+        "sync": false,
+        "title": "Dungeon Reset",
+        "identifier": "dcdcc8c7-932e-4f60-a900-5f19934eb6cf",
+        "uiSelector": true,
+        "epList": {
+          "6": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/6/1/",
+          "74": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/74/1/"
+        }
+      }
+    },
+    {
+      "url": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/65/1/",
+      "expected": {
+        "sync": true,
+        "title": "Dungeon Reset",
+        "identifier": "dcdcc8c7-932e-4f60-a900-5f19934eb6cf",
+        "overviewUrl": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/",
+        "episode": 65,
+        "uiSelector": false
+      }
+    }
+  ]
+}

--- a/src/pages/Guya/main.ts
+++ b/src/pages/Guya/main.ts
@@ -1,28 +1,18 @@
 import { pageInterface } from '../pageInterface';
 
-const excluded = ['imgur'];
-
 export const Guya: pageInterface = {
-  name: 'Guya & Cubari',
-  domain: ['https://guya.moe', 'https://cubari.moe'],
+  name: 'Guya',
+  domain: ['https://guya.moe'],
   languages: ['English'],
   type: 'manga',
   isSyncPage(url) {
-    if (
-      url.split('/')[3] === 'read' &&
-      !excluded.includes(url.split('/')[4]) &&
-      url.split('/').length >= 8
-    ) {
+    if (url.split('/')[3] === 'read' && url.split('/').length >= 8) {
       return true;
     }
     return false;
   },
   isOverviewPage(url) {
-    if (
-      url.split('/')[3] === 'read' &&
-      !excluded.includes(url.split('/')[4]) &&
-      url.split('/').length >= 6
-    ) {
+    if (url.split('/')[3] === 'read' && url.split('/').length >= 6) {
       return true;
     }
     return false;

--- a/src/pages/Guya/meta.json
+++ b/src/pages/Guya/meta.json
@@ -1,5 +1,5 @@
 {
   "urls": {
-    "match": ["*://guya.moe/*", "*://cubari.moe/*"]
+    "match": ["*://guya.moe/*"]
   }
 }

--- a/src/pages/Guya/tests.json
+++ b/src/pages/Guya/tests.json
@@ -25,30 +25,6 @@
         "episode": 210,
         "uiSelector": false
       }
-    },
-    {
-      "url": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/",
-      "expected": {
-        "sync": false,
-        "title": "Dungeon Reset",
-        "identifier": "dcdcc8c7-932e-4f60-a900-5f19934eb6cf",
-        "uiSelector": true,
-        "epList": {
-          "6": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/6/1/",
-          "74": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/74/1/"
-        }
-      }
-    },
-    {
-      "url": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/65/1/",
-      "expected": {
-        "sync": true,
-        "title": "Dungeon Reset",
-        "identifier": "dcdcc8c7-932e-4f60-a900-5f19934eb6cf",
-        "overviewUrl": "https://cubari.moe/read/mangadex/dcdcc8c7-932e-4f60-a900-5f19934eb6cf/",
-        "episode": 65,
-        "uiSelector": false
-      }
     }
   ]
 }

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -136,6 +136,7 @@ import { MangaReader } from './MangaReader/main';
 import { AnimeOnsen } from './AnimeOnsen/main';
 import { Puray } from './Puray/main';
 import { Animetoast } from './Animetoast/main';
+import { Cubari } from './Cubari/main';
 
 export const pages = {
   nineAnime,
@@ -276,4 +277,5 @@ export const pages = {
   AnimeOnsen,
   Puray,
   Animetoast,
+  Cubari,
 };


### PR DESCRIPTION
Currently the code for Guya/Cubari just looks at the URL to get the chapter number, but this is inaccurate for Cubari most of the time because of extra chapters being counted as regular chapters (ex. [if Chapter 11.5 is the first extra chapter, the URL for it will be 12](https://cubari.moe/read/mangasee/Spy-X-Family/)).

Specifically for the MangaSee (but possibly other) proxy, this can be fixed by looking at the chapter title, which can be found in the HTML, instead of the URL. After finding the chapter title, we can extract the accurate chapter number from there.

I made a new Cubari source and removed Cubari support from the Guya page, but I don't know if this is better or not.