### PR TITLE
Add missing video domains for dood player

### DIFF
--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -16,6 +16,8 @@
       "https://goload.pro/embedplus*",
       "https://vizcloud.live/embed/*",
       "https://vizcloud.digital/embed/*",
+      "https://dood.video/*",
+      "https://dood.pm/e/*",
       "https://voe-unblock.com/e/*",
       "https://kaast1.com/*"
     ]

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -436,9 +436,11 @@ module.exports = {
       '*://dood.watch/*',
       '*://doodstream.com/*',
       '*://dood.la/*',
+      '*://*.dood.video/*',
       '*://dood.ws/e/*',
       '*://dood.sh/e/*',
       '*://dood.so/e/*',
+      '*://dood.pm/e/*',
     ],
   },
   // animedao.to


### PR DESCRIPTION
These domains are currently used for dood player on otakufr.co.