### PR TITLE
Added short Skip Forward/Backward shortcut to Player

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -854,6 +854,34 @@
       }
     }
   },
+  "settings_Shortcuts_Short_Skip_Forward": {
+    "message": "Skips forward the video",
+    "description": "Description for the the video skip forward shortcut"
+  },
+  "settings_Shortcuts_Short_Skip_Backward": {
+    "message": "Skips backward the video",
+    "description": "Description for the the video skip backward shortcut"
+  },
+  "settings_Short_Skip_Forward": {
+    "message": "Set forward skip length ($Seconds$ seconds)",
+    "description": "Skips video seconds",
+    "placeholders": {
+      "Seconds": {
+        "content": "$1",
+        "example": "30"
+      }
+    }
+  },
+  "settings_Short_Skip_Backward": {
+    "message": "Set backward skip length ($Seconds$ seconds)",
+    "description": "Skips video seconds",
+    "placeholders": {
+      "Seconds": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
   "settings_UpdateCheck": {
     "message": "Update Check",
     "description": "Update Check"

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -71,6 +71,12 @@ export const settingsObj = {
     introSkip: 85,
     introSkipFwd: [17, 39],
     introSkipBwd: [17, 37],
+
+    shortSkipFwd: [],
+    shortSkipBwd: [],
+    shortSkipFwdInterval: 30,
+    shortSkipBwdInterval: 10,
+
     nextEpShort: [],
     correctionShort: [67],
     syncShort: [],

--- a/src/index-webextension/content.ts
+++ b/src/index-webextension/content.ts
@@ -104,10 +104,16 @@ function messagePageListener(page) {
     con.log('[content] Shortcut', shortcut);
     switch (shortcut.shortcut) {
       case 'introSkipFwd':
-        addVideoTime(true);
+        addVideoTime(true, false);
         break;
       case 'introSkipBwd':
-        addVideoTime(false);
+        addVideoTime(false, false);
+        break;
+      case 'shortSkipFwd':
+        addVideoTime(true, true);
+        break;
+      case 'shortSkipBwd':
+        addVideoTime(false, true);
         break;
       case 'nextEpShort':
         page.openNextEp();
@@ -122,7 +128,7 @@ function messagePageListener(page) {
       default:
     }
 
-    async function addVideoTime(forward: boolean) {
+    async function addVideoTime(forward: boolean, shortSkip: boolean) {
       if (typeof page.tempPlayer === 'undefined') {
         if (!timeAddCb) {
           con.error('[content] No iframe and onsite player found');
@@ -131,7 +137,16 @@ function messagePageListener(page) {
         timeAddCb(forward);
         return;
       }
-      let time = parseInt(await api.settings.getAsync('introSkip'));
+      let time;
+      if (shortSkip) {
+        if (forward) {
+          time = parseInt(await api.settings.getAsync('shortSkipFwdInterval'));
+        } else {
+          time = parseInt(await api.settings.getAsync('shortSkipBwdInterval'));
+        }
+      } else {
+        time = parseInt(await api.settings.getAsync('introSkip'));
+      }
       if (!forward) time = 0 - time;
 
       const totalTime = page.tempPlayer.currentTime + time;

--- a/src/minimal/minimalApp/settings.vue
+++ b/src/minimal/minimalApp/settings.vue
@@ -343,6 +343,20 @@
         <numberInput v-if="isExtension()" option="introSkip" :min="5">{{
           lang('settings_introSkip', [options.introSkip])
         }}</numberInput>
+
+        <shortcut v-if="isExtension()" option="shortSkipFwd">{{
+          lang('settings_Shortcuts_Short_Skip_Forward')
+        }}</shortcut>
+        <numberInput v-if="isExtension()" option="shortSkipFwdInterval" :min="2">{{
+          lang('settings_Short_Skip_Forward', [options.shortSkipFwdInterval])
+        }}</numberInput>
+
+        <shortcut v-if="isExtension()" option="shortSkipBwd">{{
+          lang('settings_Shortcuts_Short_Skip_Backward')
+        }}</shortcut>
+        <numberInput v-if="isExtension()" option="shortSkipBwdInterval" :min="2">{{
+          lang('settings_Short_Skip_Backward', [options.shortSkipBwdInterval])
+        }}</numberInput>
       </div>
 
       <div

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -180,6 +180,8 @@ const shortcutOptions = [
   //
   'introSkipFwd',
   'introSkipBwd',
+  'shortSkipFwd',
+  'shortSkipBwd',
   'nextEpShort',
   'correctionShort',
   'syncShort',


### PR DESCRIPTION
Added a short Skip Forward/Backward shortcut with separate time intervals.
Default Skip Forward is 30sec and Skip Backward is 10sec (Configurable from settings). 
The shortcuts are not preconfigured to avoid confusion with old users (any default shortcut suggestions?).
It follows the same logic as Skip Intro.