### PR TITLE
Change url used for 9anime search

### DIFF
--- a/src/pages/nineAnime/meta.json
+++ b/src/pages/nineAnime/meta.json
@@ -1,5 +1,5 @@
 {
-  "search": "https://9anime.to/search?keyword={searchtermPlus}",
+  "search": "https://9anime.to/filter?keyword={searchtermPlus}",
   "urls": {
     "match": [
       "*://*.9anime.to/watch/*",


### PR DESCRIPTION
Updated meta file for 9anime because they changed the format of their search url