### PR TITLE
Add missing StreamSB domain

### DIFF
--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -122,6 +122,8 @@
     ]
   },
   "0.9.0": {
-    "iframe": []
+    "iframe": [
+      "https://sbanh.com/e/*"
+    ]
   }
 }

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -458,6 +458,7 @@ module.exports = {
       '*://sbfull.com/e/*',
       '*://ssbstream.net/*',
       '*://streamsss.net/*',
+      '*://sbanh.com/e/*',
     ],
   },
   // gogo


### PR DESCRIPTION
This is the "[custom domain](https://streamsb.com/n29-Custom-domain.html)" used on Voiranime for StreamSB.