### PR TITLE
Fix episodes detection in overview URL on nekosama

### DIFF
--- a/src/pages/NekoSama/main.ts
+++ b/src/pages/NekoSama/main.ts
@@ -2,7 +2,7 @@ import { pageInterface } from '../pageInterface';
 
 export const NekoSama: pageInterface = {
   name: 'NekoSama',
-  domain: 'https://www.neko-sama.fr',
+  domain: 'https://neko-sama.fr',
   languages: ['French'],
   type: 'anime',
   isSyncPage(url) {
@@ -52,7 +52,10 @@ export const NekoSama: pageInterface = {
 
   overview: {
     getTitle(url) {
-      return utils.getBaseText($('#head > div.content > div > div > div > h1'));
+      return utils
+        .getBaseText($('#head > div.content > div > div > div > h1'))
+        .split(' VOSTFR')[0]
+        .split(' VF')[0];
     },
     getIdentifier(url) {
       return NekoSama.sync.getIdentifier(url);
@@ -71,7 +74,7 @@ export const NekoSama: pageInterface = {
         return utils.absoluteLink(selector.find('a').first().attr('href'), NekoSama.domain);
       },
       elementEp(selector) {
-        return Number(selector.find('a').first().text().replace(/\D+/, ''));
+        return Number(selector.find('a').first().find('span.episode').text().replace(/\D+/, ''));
       },
     },
   },

--- a/src/pages/NekoSama/tests.json
+++ b/src/pages/NekoSama/tests.json
@@ -1,27 +1,66 @@
 {
   "title": "NekoSama",
-  "url": "https://www.neko-sama.fr/",
+  "url": "https://neko-sama.fr/",
   "testCases": [
     {
-      "url": "https://www.neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vostfr",
+      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vostfr",
       "expected": {
         "sync": true,
         "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
-        "overviewUrl": "https://www.neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist",
-        "nextEpUrl": "https://www.neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04-vostfr",
+        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vostfr",
+        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04-vostfr",
         "episode": 3,
         "uiSelector": false
       }
     },
     {
-      "url": "https://www.neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist",
+      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vf",
+      "expected": {
+        "sync": true,
+        "title": "Fullmetal Alchemist: Brotherhood",
+        "identifier": "3458",
+        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vf",
+        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04-vf",
+        "episode": 3,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vostfr",
       "expected": {
         "sync": false,
-        "title": "Fullmetal Alchemist: Brotherhood ",
+        "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
-        "uiSelector": true
+        "uiSelector": true,
+        "epList": {
+          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vostfr"
+        }
       }
-    }
+    },
+    {
+      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vf",
+      "expected": {
+        "sync": false,
+        "title": "Fullmetal Alchemist: Brotherhood",
+        "identifier": "3458",
+        "uiSelector": true,
+        "epList": {
+          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vf"
+        }
+      }
+    },
+    {
+      "url": "https://neko-sama.fr/anime/info/19050-4-nin-wa-sorezore-uso-wo-tsuku-vostfr",
+      "expected": {
+        "sync": false,
+        "title": "4-nin wa Sorezore Uso wo Tsuku",
+        "identifier": "19050",
+        "uiSelector": true,
+        "epList": {
+          "2": "https://neko-sama.fr/anime/episode/19050-4-nin-wa-sorezore-uso-wo-tsuku-02-vostfr"
+        }
+      }
+    },
   ]
 }


### PR DESCRIPTION
What this PR does:
- Update tests URLs for NekoSama (remove the now unused `www.` subdomain, anime are now spited in 2 categories: vostfr and vf )
- Fix this bug: when anime title includes a digit, on overview episode number was wrong (the digit from the title and the episode number were concatenated)

What I checked:
-  Even if tests failed on GitHub (timeout), locally all tests are completed successfully.
- I build the web-extension, installed it in a clean Firefox profile and checked manually as well.