### PR TITLE
Improve anime detection on Jellyfin

### DIFF
--- a/src/pages/Jellyfin/main.ts
+++ b/src/pages/Jellyfin/main.ts
@@ -91,7 +91,7 @@ async function checkItemId(page, id, curUrl = '', video = false) {
           const genres: any = JSON.parse(response2.responseText);
           con.log('genres', genres);
           if (
-            genres.Path.includes('Anime') ||
+            genres.Path.toLowerCase().includes('anime') ||
             genres.GenreItems.find(genre => genre.Name.toLowerCase() === 'anime')
           ) {
             con.info('Anime detected');

--- a/src/pages/Jellyfin/main.ts
+++ b/src/pages/Jellyfin/main.ts
@@ -92,7 +92,8 @@ async function checkItemId(page, id, curUrl = '', video = false) {
           con.log('genres', genres);
           if (
             genres.Path.toLowerCase().includes('anime') ||
-            genres.GenreItems.find(genre => genre.Name.toLowerCase() === 'anime')
+            genres.GenreItems.find(genre => genre.Name.toLowerCase() === 'anime') ||
+            genres.Tags.find(tag => tag.toLowerCase() === 'anime')
           ) {
             con.info('Anime detected');
             if (curUrl) {


### PR DESCRIPTION
Now also recognises an anime if the path name is written in lowercase.

And it looks in the tags to see if its tagged as an anime as the default metadata provider of Jellyfin likes to add the 'Animation' genre instead of 'Anime', but always adds 'Anime' to tags.