### PR TITLE
Fix: load myanimelist lists on safari/tampermonkey.

### DIFF
--- a/src/_provider/MyAnimeList_api/list.ts
+++ b/src/_provider/MyAnimeList_api/list.ts
@@ -93,7 +93,7 @@ export class UserList extends ListAbstract {
       type: 'GET',
       path: `users/@me/${this.listType}list?nsfw=true&limit=${this.limit}&offset=${this.offset}${curSt}${sorting}`,
       fields: [
-        'list_status{tags,is_rewatching,is_rereading,start_date,finish_date}',
+        'list_status%7Btags,is_rewatching,is_rereading,start_date,finish_date%7D',
         'num_episodes',
         'num_chapters',
         'num_volumes',

--- a/src/_provider/MyAnimeList_api/single.ts
+++ b/src/_provider/MyAnimeList_api/single.ts
@@ -191,7 +191,7 @@ export class Single extends SingleAbstract {
       type: 'GET',
       path: `${this.type}/${this.ids.mal}`,
       fields: [
-        'my_list_status{tags,is_rewatching,is_rereading,num_times_rewatched,num_times_reread,start_date,finish_date}',
+        'my_list_status%7Btags,is_rewatching,is_rereading,num_times_rewatched,num_times_reread,start_date,finish_date%7D',
         'num_episodes',
         'mean',
         // Manga


### PR DESCRIPTION
Tampermonkey on safari can't fetch the lists from MAL. Further debug indicates that GM_xmlhttpRequest can't parse the url, and url encoding the braces resolves the issue.

On my limited knowledge, I assume that url encoded strings are a safe bet; but I'm totally inexpert on web development and I'm not sure the effect on other browsers.