### PR TITLE
Update NekoSama episode detection

### DIFF
--- a/src/pages/NekoSama/main.ts
+++ b/src/pages/NekoSama/main.ts
@@ -13,7 +13,7 @@ export const NekoSama: pageInterface = {
   },
   sync: {
     getTitle(url) {
-      return j.$('.details > div > h1 > a').text();
+      return j.$('.details > div > h1 > a').text() || j.$('.details > div > h2 > a').text();
     },
     getIdentifier(url) {
       const urlPart5 = utils.urlPart(url, 5);
@@ -27,7 +27,12 @@ export const NekoSama: pageInterface = {
       return identifierMatches[0];
     },
     getOverviewUrl(url) {
-      return NekoSama.domain + (j.$('.details > div > h1 > a').attr('href') || '');
+      return (
+        NekoSama.domain +
+        (j.$('.details > div > h1 > a').attr('href') ||
+          j.$('.details > div > h2 > a').attr('href') ||
+          '')
+      );
     },
     getEpisode(url) {
       const headerElementText = j
@@ -36,7 +41,7 @@ export const NekoSama: pageInterface = {
 
       if (!headerElementText) return NaN;
 
-      return Number(headerElementText.split(' Episode ').pop());
+      return Number(headerElementText.split('Episode ').pop());
     },
     nextEpUrl(url) {
       return utils.absoluteLink(

--- a/src/pages/NekoSama/tests.json
+++ b/src/pages/NekoSama/tests.json
@@ -3,62 +3,73 @@
   "url": "https://neko-sama.fr/",
   "testCases": [
     {
-      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vostfr",
+      "url": "https://neko-sama.fr/anime/episode/19080-tomo-chan-wa-onnanoko-07_vostfr",
+      "expected": {
+        "sync": true,
+        "title": "Tomo-chan Is a Girl!",
+        "identifier": "19080",
+        "overviewUrl": "https://neko-sama.fr/anime/info/19080-tomo-chan-wa-onnanoko_vostfr",
+        "episode": 7,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03_vostfr",
       "expected": {
         "sync": true,
         "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
-        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vostfr",
-        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04-vostfr",
+        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist_vostfr",
+        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04_vostfr",
         "episode": 3,
         "uiSelector": false
       }
     },
     {
-      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vf",
+      "url": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03_vf",
       "expected": {
         "sync": true,
         "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
-        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vf",
-        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04-vf",
+        "overviewUrl": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist_vf",
+        "nextEpUrl": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-04_vf",
         "episode": 3,
         "uiSelector": false
       }
     },
     {
-      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vostfr",
+      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist_vostfr",
       "expected": {
         "sync": false,
         "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
         "uiSelector": true,
         "epList": {
-          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vostfr"
+          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03_vostfr"
         }
       }
     },
     {
-      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-vf",
+      "url": "https://neko-sama.fr/anime/info/3458-hagane-no-renkinjutsushi-fullmetal-alchemist_vf",
       "expected": {
         "sync": false,
         "title": "Fullmetal Alchemist: Brotherhood",
         "identifier": "3458",
         "uiSelector": true,
         "epList": {
-          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03-vf"
+          "3": "https://neko-sama.fr/anime/episode/3458-hagane-no-renkinjutsushi-fullmetal-alchemist-03_vf"
         }
       }
     },
     {
-      "url": "https://neko-sama.fr/anime/info/19050-4-nin-wa-sorezore-uso-wo-tsuku-vostfr",
+      "url": "https://neko-sama.fr/anime/info/19050-4-nin-wa-sorezore-uso-wo-tsuku_vostfr",
       "expected": {
         "sync": false,
         "title": "4-nin wa Sorezore Uso wo Tsuku",
         "identifier": "19050",
         "uiSelector": true,
         "epList": {
-          "2": "https://neko-sama.fr/anime/episode/19050-4-nin-wa-sorezore-uso-wo-tsuku-02-vostfr"
+          "2": "https://neko-sama.fr/anime/episode/19050-4-nin-wa-sorezore-uso-wo-tsuku-02_vostfr"
         }
       }
     },


### PR DESCRIPTION
* URL format has changed: tests were broken
* For episode that have been published recently (I don't know if this will be permanent), anime title is no longer in `h1`, but in `h2` along with the episode number, separated by a `<br/>` : episode number detection was broken by this change
Example of what is currently at `.details > div`:
```html
<div class="info">
<h2>
<a href="/anime/info/19080-tomo-chan-wa-onnanoko_vostfr">Tomo-chan Is a Girl!</a>
<br>
Episode 7
</h2>
</div>
```