### PR TITLE
Add missing domain for voe player

### DIFF
--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -136,6 +136,7 @@
       "https://guidon40hyporadius9.com/e/*",
       "https://cyamidpulverulence530.com/e/*",
       "https://www.turkanime.co/embed/*",
+      "https://boonlessbestselling244.com/e/*",
       "https://aniyan.net/jwplayer/*"
     ]
   }

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -592,6 +592,7 @@ module.exports = {
       '*://449unceremoniousnasoseptal.com/e/*',
       '*://guidon40hyporadius9.com/e/*',
       '*://cyamidpulverulence530.com/e/*',
+      '*://boonlessbestselling244.com/e/*',
     ],
   },
   // animewho


### PR DESCRIPTION
* Domain used on voiranime.com
* Partially automated with [this script](https://gist.github.com/louisroyer/7002619daf1313f6ea62dfd1e4c50281)