### PR TITLE
Use VoirAnime subdomain

### DIFF
--- a/src/pages/Voiranime/meta.json
+++ b/src/pages/Voiranime/meta.json
@@ -1,6 +1,6 @@
 {
   "search": "https://voiranime.com/?s={searchtermPlus}",
   "urls": {
-    "match": ["*://voiranime.com/*"]
+    "match": ["*://voiranime.com/*", "*://v2.voiranime.com/*"]
   }
 }

--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -124,6 +124,9 @@
     ]
   },
   "0.9.2": {
+    "Voiranime": [
+      "https://v2.voiranime.com/*"
+    ],
     "YugenAnime": [
       "https://yugenanime.ro/*"
     ],


### PR DESCRIPTION
Since 2023-02-17, voiranime.com redirects to the subdomain v2.voiranime.com The use of "v2" let me think it is only temporary, but currently VoirAnime is no longer detected out-of-the-box.
This commit should close #1625.