### PR TITLE
Update shikimori domain name

### DIFF
--- a/src/_provider/Shikimori/helper.ts
+++ b/src/_provider/Shikimori/helper.ts
@@ -4,11 +4,11 @@ import { Cache } from '../../utils/Cache';
 
 const clientId = 'z3NJ84kK9iy5NU6SnhdCDB38rr4-jFIJ67bMIUDzdoo';
 
-export const authUrl = `https://shikimori.one/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Fmalsync.moe%2Fshikimori%2Foauth&response_type=code&scope=user_rates`;
+export const authUrl = `https://shikimori.me/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Fmalsync.moe%2Fshikimori%2Foauth&response_type=code&scope=user_rates`;
 
-const apiDomain = 'https://shikimori.one/api/';
+const apiDomain = 'https://shikimori.me/api/';
 
-export const domain = 'https://shikimori.one';
+export const domain = 'https://shikimori.me';
 
 export async function apiCall(options: {
   type: 'GET' | 'PUT' | 'DELETE' | 'POST';
@@ -47,7 +47,7 @@ export async function apiCall(options: {
 
   if (options.auth) {
     delete headers.Authorization;
-    url = 'https://shikimori.one/oauth/token';
+    url = 'https://shikimori.me/oauth/token';
   }
 
   return api.request

--- a/src/_provider/Shikimori/metaOverview.ts
+++ b/src/_provider/Shikimori/metaOverview.ts
@@ -6,7 +6,7 @@ export class MetaOverview extends MetaOverviewAbstract {
   constructor(url) {
     super(url);
     this.logger = this.logger.m('Shiki');
-    if (url.match(/shikimori\.one\/(animes|mangas)\/\D?\d+/i)) {
+    if (url.match(/shikimori\.me\/(animes|mangas)\/\D?\d+/i)) {
       this.type = utils.urlPart(url, 3) === 'animes' ? 'anime' : 'manga';
       const res = utils.urlPart(url, 4).match(/^\D?(\d+)/);
       if (res && res[1]) {
@@ -204,7 +204,7 @@ export class MetaOverview extends MetaOverviewAbstract {
       data.meta.studios.forEach(i => {
         studios.push({
           text: i.name,
-          url: `https://shikimori.one/animes/studio/${i.id}`,
+          url: `https://shikimori.me/animes/studio/${i.id}`,
         });
       });
 
@@ -219,7 +219,7 @@ export class MetaOverview extends MetaOverviewAbstract {
     data.meta.genres.forEach(i => {
       genres.push({
         text: i.name,
-        url: `https://shikimori.one/${this.type}s/genre/${i.id}`,
+        url: `https://shikimori.me/${this.type}s/genre/${i.id}`,
       });
     });
     if (genres.length)

--- a/src/_provider/Shikimori/single.ts
+++ b/src/_provider/Shikimori/single.ts
@@ -19,7 +19,7 @@ export class Single extends SingleAbstract {
   authenticationUrl = helper.authUrl;
 
   protected handleUrl(url) {
-    if (url.match(/shikimori\.one\/(animes|mangas|ranobe)\/\D?\d+/i)) {
+    if (url.match(/shikimori\.me\/(animes|mangas|ranobe)\/\D?\d+/i)) {
       this.type = utils.urlPart(url, 3) === 'animes' ? 'anime' : 'manga';
       const res = utils.urlPart(url, 4).match(/^\D?(\d+)/);
       if (res && res[1]) {

--- a/src/utils/slugs.ts
+++ b/src/utils/slugs.ts
@@ -12,7 +12,7 @@ const malRegex = /^https:\/\/myanimelist\.net\/(anime|manga)\/(\d+)(\/|$)/;
 const anilistRegex = /^https:\/\/anilist\.co\/(anime|manga)\/(\d+)(\/|$)/;
 const kitsuRegex = /^https:\/\/kitsu\.io\/(anime|manga)\/([^/]+)(\/|$)/;
 const simklRegex = /^https:\/\/simkl\.com\/(anime|manga)\/(\d+)(\/|$)/;
-const shikiRegex = /^https:\/\/shikimori\.one\/(animes|mangas|ranobe)\/\D?(\d+)/;
+const shikiRegex = /^https:\/\/shikimori\.me\/(animes|mangas|ranobe)\/\D?(\d+)/;
 const localRegex = /^local:\/\/([^/]+)\/(anime|manga)\/([^/]+)(\/|$)/;
 
 export function urlToSlug(url: string): slugObject {
@@ -92,7 +92,7 @@ export function pathToUrl(path: Path): string {
     return `https://simkl.com/${path.type}/${path.slug.substring(2)}`;
   }
   if (path.slug.startsWith('shi:')) {
-    return `https://shikimori.one/${path.type}s/${path.slug.substring(4)}`;
+    return `https://shikimori.me/${path.type}s/${path.slug.substring(4)}`;
   }
   if (path.slug.startsWith('l:')) {
     const match = path.slug.match(/^l:([^:]+)::([^:]+)$/);

--- a/webpackConfig/httpPermissions.json
+++ b/webpackConfig/httpPermissions.json
@@ -16,5 +16,5 @@
   "https://api.malsync.moe/",
   "https://api.myanimelist.net/",
   "https://api.mangadex.org/",
-  "https://shikimori.one/"
+  "https://shikimori.me/"
 ]


### PR DESCRIPTION
From .one to .me domain as one has been temp(?) lost

Source: https://shikimori.me/forum/news/505429-novyy-domen-sayta-shikimori-me Important part from there is:
  `В любом случае новый домен сайта теперь shikimori.me. Даже когда/если
  я верну старый домен, то основным доменом сайта останется новый, чтобы
  не устраивать еще один переезд.`
Which roughly translates as shikimori.me would the main domain even after restoring old ones.