### PR TITLE
Add new Voiranime subdomain

### DIFF
--- a/src/pages/Voiranime/meta.json
+++ b/src/pages/Voiranime/meta.json
@@ -1,6 +1,6 @@
 {
   "search": "https://voiranime.com/?s={searchtermPlus}",
   "urls": {
-    "match": ["*://voiranime.com/*", "*://v2.voiranime.com/*", "*://v3.voiranime.com/*", "*://v4.voiranime.com/*"]
+    "match": ["*://voiranime.com/*", "*://v2.voiranime.com/*", "*://v3.voiranime.com/*", "*://v4.voiranime.com/*", "*://v5.voiranime.com/*"]
   }
 }

--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -151,6 +151,9 @@
     "iframe": []
   },
   "0.9.5": {
+    "Voiranime": [
+      "https://v5.voiranime.com/*"
+    ],
     "Zoro": [
       "https://aniwatch.to/*"
     ],


### PR DESCRIPTION
Recently, voiranime changed their subdomain from v4.voiranime.com
This pull request adds its new one which is v5.voiranime.com

EDIT: Might need to change the version for the diffUrls.json file