### PR TITLE
Change aniwave search url from 9anime to aniwave

### DIFF
--- a/src/pages/nineAnime/meta.json
+++ b/src/pages/nineAnime/meta.json
@@ -1,5 +1,5 @@
 {
-  "search": "https://9anime.to/filter?keyword={searchtermPlus}",
+  "search": "https://aniwave.to/filter?keyword={searchtermPlus}",
   "urls": {
     "match": [
       "*://*.9anime.to/watch/*",


### PR DESCRIPTION
This URL was missed with the recent domain change and generally not noticeable unless the anime is yet to release or cannot be found.