### PR TITLE
[AnimeGO] fix getTitle

### DIFF
--- a/src/pages/AnimeGO/main.ts
+++ b/src/pages/AnimeGO/main.ts
@@ -21,7 +21,25 @@ export const AnimeGO: pageInterface = {
     },
     getTitle(url) {
       const jsonData = JSON.parse(j.$('script[type~="application/ld+json"]').text());
-      return jsonData.alternativeHeadline[1]; // There're 3 languages there: Japanese, English, 日本語 (jp)
+      switch (jsonData.alternativeHeadline.length) {
+        case 0: {
+          // no headlines
+          // example: https://animego.org/anime/moya-geroyskaya-akademiya-s1-294
+          return jsonData.name; // Return Russian title, if no English found
+        }
+        case 3: {
+          // Japanese, English, 日本語 (jp)
+          // example: https://animego.org/anime/horimiya-1686
+          return jsonData.alternativeHeadline[1];
+        }
+        default: {
+          // 1 or 2. Anyway, English is first
+          // examples:
+          // 1: https://animego.org/anime/velikiy-pritvorschik-1573
+          // 2: https://animego.org/anime/vanpanchmen-put-k-stanovleniyu-geroem-14
+          return jsonData.alternativeHeadline[0];
+        }
+      }
     },
     getEpisode(url) {
       return parseInt(j.$('div#video-carousel .video-player__active').attr('data-episode') || '1');


### PR DESCRIPTION
There are few anime overviews that doesn't have English and Japanese title

Example: https://animego.org/anime/oshi-no-ko-2307 \(Obviously, [Oshi no Ko](https://anilist.co/anime/150672/Oshi-No-Ko/)\)

### Before fix:
- On 0.49% overviews extension crashes (no alternative headlines at all or only English)
- 30.56%: Japanese (日本語) headline is chosen

### After fix:
- Uses Russian title if no title found
- Locating English title correctly