### PR TITLE
[hachi] Disable offset handler

### DIFF
--- a/src/pages/hachi/main.ts
+++ b/src/pages/hachi/main.ts
@@ -45,7 +45,7 @@ export const hachi: pageInterface = {
       j.$('div.mantine-Grid-root').first().prepend(j.html(selector));
     },
     list: {
-      offsetHandler: true,
+      offsetHandler: false,
       elementsSelector() {
         return j.$('div.mantine-SimpleGrid-root > a');
       },


### PR DESCRIPTION
Some changes were made to the overview page, so the offset handler no longer works. I'll likely make a pr at some other time that is able to fetch all the chapters, but this is a quick fix for now.