### PR TITLE
Fix: Guya/Cubari chapter progress detection

### DIFF
--- a/src/pages/Guya/main.ts
+++ b/src/pages/Guya/main.ts
@@ -46,8 +46,9 @@ export const Guya: pageInterface = {
     readerConfig: [
       {
         current: {
-          selector: '.ReaderImageWrapper',
-          mode: 'countAbove',
+          selector: '.rdr-page-selector-counter',
+          mode: 'text',
+          regex: '^\\d+',
         },
         total: {
           selector: '.ReaderImageWrapper',

--- a/src/pages/Guya/main.ts
+++ b/src/pages/Guya/main.ts
@@ -51,8 +51,9 @@ export const Guya: pageInterface = {
           regex: '^\\d+',
         },
         total: {
-          selector: '.ReaderImageWrapper',
-          mode: 'count',
+          selector: '.rdr-page-selector-counter',
+          mode: 'text',
+          regex: '\\d+$',
         },
       },
     ],


### PR DESCRIPTION
Fixes chapter progress detection on guya/cubari.moe when using RTL (right-to-left reading mode). The reader reverses the order of the page elements, so `countAbove` on the `.ReaderImageWrapper` selector reports the wrong page number. The selector worked correctly when reading vertically and left-to-right.
