### PR TITLE
update toonily page to support webtoon and change domain

### DIFF
--- a/src/pages/Toonily/main.ts
+++ b/src/pages/Toonily/main.ts
@@ -2,7 +2,7 @@ import { pageInterface } from '../pageInterface';
 
 export const Toonily: pageInterface = {
   name: 'Toonily',
-  domain: 'https://toonily.net',
+  domain: ['https://toonily.com'],
   languages: ['English'],
   type: 'manga',
   isSyncPage(url) {
@@ -10,7 +10,7 @@ export const Toonily: pageInterface = {
   },
   sync: {
     getTitle(url) {
-      return j.$('.breadcrumb li > a[href*="/manga/"]').text().trim();
+      return j.$('.breadcrumb li > a[href*="/webtoon/"]').text().trim();
     },
     getIdentifier(url) {
       return url.split('/')[4];
@@ -18,7 +18,7 @@ export const Toonily: pageInterface = {
     getOverviewUrl(url) {
       return (
         utils.absoluteLink(
-          j.$('.breadcrumb li > a[href*="/manga/"]').attr('href'),
+          j.$('.breadcrumb li > a[href*="/webtoon/"]').attr('href'),
           Toonily.domain,
         ) || ''
       );
@@ -71,7 +71,7 @@ export const Toonily: pageInterface = {
     );
     j.$(document).ready(function () {
       if (
-        utils.urlPart(page.url, 3) === 'manga' &&
+        utils.urlPart(page.url, 3) === 'webtoon' &&
         utils.urlPart(page.url, 4) !== undefined &&
         utils.urlPart(page.url, 4).length > 0
       ) {

--- a/src/pages/Toonily/meta.json
+++ b/src/pages/Toonily/meta.json
@@ -1,6 +1,6 @@
 {
-  "search": "https://toonily.net/?s={searchtermPlus}&post_type=wp-manga",
+  "search": "https://toonily.com/?s={searchtermPlus}&post_type=wp-manga",
   "urls": {
-    "match": ["*://toonily.net/manga/*"]
+    "match": ["*://toonily.com/webtoon/*"]
   }
 }

--- a/src/pages/Toonily/tests.json
+++ b/src/pages/Toonily/tests.json
@@ -1,29 +1,29 @@
 {
   "title": "Toonily",
-  "url": "https://toonily.net/",
+  "url": "https://toonily.com/",
   "testCases": [
     {
-      "url": "https://toonily.net/manga/above-all-gods/chapter-173-5/",
+      "url": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-125/",
       "expected": {
         "sync": true,
-        "title": "Above All Gods",
-        "identifier": "above-all-gods",
-        "overviewUrl": "https://toonily.net/manga/above-all-gods/",
-        "nextEpUrl": "https://toonily.net/manga/above-all-gods/chapter-174/",
-        "episode": 173,
+        "title": "Skeleton Soldier Couldn’t Protect the Dungeon",
+        "identifier": "skeleton-protect-dungeon",
+        "overviewUrl": "https://toonily.com/webtoon/skeleton-protect-dungeon/",
+        "nextEpUrl": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-126/",
+        "episode": 125,
         "uiSelector": false
       }
     },
     {
-      "url": "https://toonily.net/manga/above-all-gods/",
+      "url": "https://toonily.com/webtoon/skeleton-protect-dungeon/",
       "expected": {
         "sync": false,
-        "title": "Above All Gods",
-        "identifier": "above-all-gods",
+        "title": "Skeleton Soldier Couldn’t Protect the Dungeon",
+        "identifier": "skeleton-protect-dungeon",
         "uiSelector": true,
         "epList": {
-          "20": "https://toonily.net/manga/above-all-gods/chapter-20/",
-          "177": "https://toonily.net/manga/above-all-gods/chapter-177/"
+          "120": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-120/",
+          "125": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-125/"
         }
       }
     }


### PR DESCRIPTION
Hey I noticed that toonily.com is not supported, while considering adding support I noticed that, now dead, toonily.net was supported, so I went ahead and adjusted the implementation. toonily.com does not have manga, only webtoon/manhwa, so the change was mostly as simple as switching out manga for webtoon. The CSS and such is unchanged and when loading the extension from a folder it seems to work as expected.
If I should change something, please let me know :)

Kind regards
Alistair1231
