### PR TITLE
Fix malsync ui not loading on sync page for miruro when loading directly

### DIFF
--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -61,10 +61,21 @@ export const Miruro: pageInterface = {
     api.storage.addStyle(
       require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
     );
-    ready();
-    utils.urlChangeDetect(function () {
+    utils.urlChangeDetect(() => {
       ready();
     });
+    utils.waitUntilTrue(
+      () => {
+        if (j.$('.player[data-media-player]').length) {
+          return true;
+        }
+        return false;
+      },
+      () => {
+        ready();
+        // globalThis.page = page; uncomment for testing from console
+      },
+    );
     function ready() {
       page.reset();
       page.handlePage();


### PR DESCRIPTION
Hello :) 
As continuation of the last PR which added the website support for https://www.miruro.tv and https://www.miruro.online
https://github.com/MALSync/MALSync/pull/2396 
There is a bug where if we load the sync page (with video player) directly, the Malsync UI is not loading. But when navigating, it loads fine. eg> https://www.miruro.tv/watch/153288/kaijuu-8-gou/6 
I have added a waitUntilTrue on init to call the necessary functions.. and keeping rest as is.
waitUntilTrue will only get called once on page load, navigation won't reload the page so it won't get called again.

Regards,
Debjoy