### PR TITLE
Fix episode detection not working after Miruro player page url changes

### DIFF
--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -6,7 +6,11 @@ export const Miruro: pageInterface = {
   languages: ['English'],
   type: 'anime',
   isSyncPage(url) {
-    return utils.urlPart(url, 3) === 'watch' && utils.urlPart(url, 5).trim() !== '';
+    return (
+      utils.urlPart(url, 3) === 'watch' &&
+      utils.urlParam(url, 'id') !== null &&
+      utils.urlParam(url, 'ep') !== null
+    );
   },
   isOverviewPage(url) {
     return false;
@@ -16,17 +20,17 @@ export const Miruro: pageInterface = {
       return j.$('.anime-title').text();
     },
     getIdentifier(url) {
-      return `${utils.urlPart(url, 4)}`;
+      return `${utils.urlParam(url, 'id')}`;
     },
     getOverviewUrl(url) {
-      const href = `https://${window.location.hostname}/watch/${utils.urlPart(url, 4)}`;
+      const href = `https://${window.location.hostname}/watch?id=${utils.urlParam(url, 'id')}`;
       if (typeof href !== 'undefined') {
         return utils.absoluteLink(href, Miruro.domain);
       }
       return '';
     },
     getEpisode(url) {
-      const temp = utils.urlPart(url, 5);
+      const temp = utils.urlParam(url, 'ep');
       if (!temp) return NaN;
       return Number(temp);
     },
@@ -35,7 +39,7 @@ export const Miruro: pageInterface = {
       const nextEpisodeNumber = Miruro.sync.getEpisode(url) + 1;
       let href;
       if (totalEpisodeNumber.length > 1 && nextEpisodeNumber <= Number(totalEpisodeNumber[1]) + 1) {
-        href = `https://${window.location.hostname}/watch/${utils.urlPart(url, 4)}/${nextEpisodeNumber}`;
+        href = `https://${window.location.hostname}/watch?id=${utils.urlParam(url, 'id')}&ep=${nextEpisodeNumber}`;
       }
       if (typeof href !== 'undefined') {
         return utils.absoluteLink(href, Miruro.domain);
@@ -63,12 +67,12 @@ export const Miruro: pageInterface = {
     );
     let inte: NodeJS.Timer;
     utils.urlChangeDetect(() => ready());
-    j.$(document).ready(() => ready());
+    j.$(() => ready());
     function ready() {
       page.reset();
       clearInterval(inte);
       inte = utils.waitUntilTrue(
-        () => Miruro.sync.getTitle(window.location.href),
+        () => Miruro.sync.getTitle(window.location.href) && Miruro.isSyncPage(window.location.href),
         () => page.handlePage(),
       );
     }

--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -83,9 +83,9 @@ export const Miruro: pageInterface = {
     utils.urlChangeDetect(() => ready());
     j.$(() => ready());
     function ready() {
+      page.reset();
       if (!Miruro.isSyncPage(window.location.href) && !Miruro.isOverviewPage!(window.location.href))
         return;
-      page.reset();
       clearInterval(inte);
       inte = utils.waitUntilTrue(
         () => Miruro.sync.getTitle(window.location.href),

--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -26,7 +26,7 @@ export const Miruro: pageInterface = {
       return '';
     },
     getEpisode(url) {
-      const temp = utils.urlPart(url, 6);
+      const temp = utils.urlPart(url, 5);
       if (!temp) return NaN;
       return Number(temp);
     },
@@ -35,7 +35,7 @@ export const Miruro: pageInterface = {
       const nextEpisodeNumber = Miruro.sync.getEpisode(url) + 1;
       let href;
       if (totalEpisodeNumber.length > 1 && nextEpisodeNumber <= Number(totalEpisodeNumber[1]) + 1) {
-        href = `https://${window.location.hostname}/watch/${utils.urlPart(url, 4)}/${utils.urlPart(url, 5)}/${nextEpisodeNumber}`;
+        href = `https://${window.location.hostname}/watch/${utils.urlPart(url, 4)}/${nextEpisodeNumber}`;
       }
       if (typeof href !== 'undefined') {
         return utils.absoluteLink(href, Miruro.domain);

--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -13,7 +13,7 @@ export const Miruro: pageInterface = {
     );
   },
   isOverviewPage(url) {
-    return false;
+    return utils.urlPart(url, 3) === 'info' && utils.urlParam(url, 'id') !== null;
   },
   sync: {
     getTitle(url) {
@@ -23,7 +23,7 @@ export const Miruro: pageInterface = {
       return `${utils.urlParam(url, 'id')}`;
     },
     getOverviewUrl(url) {
-      const href = `https://${window.location.hostname}/watch?id=${utils.urlParam(url, 'id')}`;
+      const href = `https://${window.location.hostname}/info?id=${utils.urlParam(url, 'id')}`;
       if (typeof href !== 'undefined') {
         return utils.absoluteLink(href, Miruro.domain);
       }
@@ -61,6 +61,20 @@ export const Miruro: pageInterface = {
       j.$('.anime-title').parent().parent().before(j.html(selector));
     },
   },
+  overview: {
+    getTitle(url) {
+      return Miruro.sync.getTitle(url);
+    },
+    getIdentifier(url) {
+      return Miruro.sync.getIdentifier(url);
+    },
+    uiSelector(selector) {
+      j.$('.anime-title').parent().parent().parent().before(j.html(selector));
+    },
+    getMalUrl(provider) {
+      return Miruro.sync.getMalUrl!(provider);
+    },
+  },
   init(page) {
     api.storage.addStyle(
       require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
@@ -69,10 +83,12 @@ export const Miruro: pageInterface = {
     utils.urlChangeDetect(() => ready());
     j.$(() => ready());
     function ready() {
+      if (!Miruro.isSyncPage(window.location.href) && !Miruro.isOverviewPage!(window.location.href))
+        return;
       page.reset();
       clearInterval(inte);
       inte = utils.waitUntilTrue(
-        () => Miruro.sync.getTitle(window.location.href) && Miruro.isSyncPage(window.location.href),
+        () => Miruro.sync.getTitle(window.location.href),
         () => page.handlePage(),
       );
     }

--- a/src/pages/Miruro/tests.json
+++ b/src/pages/Miruro/tests.json
@@ -9,7 +9,7 @@
         "title": "My Hero Academia Season 6",
         "identifier": "139630",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch?id=139630",
+        "overviewUrl": "https://www.miruro.tv/info?id=139630",
         "episode": 1,
         "nextEpUrl": "https://www.miruro.tv/watch?id=139630&ep=2"
       }
@@ -21,7 +21,7 @@
         "title": "That Time I Got Reincarnated as a Slime",
         "identifier": "101280",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch?id=101280",
+        "overviewUrl": "https://www.miruro.tv/info?id=101280",
         "episode": 19,
         "nextEpUrl": "https://www.miruro.tv/watch?id=101280&ep=20"
       }
@@ -33,9 +33,18 @@
         "title": "LAID-BACK CAMP SEASON2",
         "identifier": "104459",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch?id=104459",
+        "overviewUrl": "https://www.miruro.tv/info?id=104459",
         "episode": 13,
         "nextEpUrl": ""
+      }
+    },
+    {
+      "url": "https://www.miruro.tv/info?id=163139",
+      "expected": {
+        "sync": false,
+        "title": "My Hero Academia Season 7",
+        "identifier": "163139",
+        "uiSelector": true
       }
     }
   ]

--- a/src/pages/Miruro/tests.json
+++ b/src/pages/Miruro/tests.json
@@ -3,7 +3,7 @@
   "url": "https://www.miruro.tv",
   "testCases": [
     {
-      "url": "https://www.miruro.tv/watch/139630/boku-no-hero-academia-6th-season/1",
+      "url": "https://www.miruro.tv/watch/139630/1",
       "expected": {
         "sync": true,
         "title": "My Hero Academia Season 6",
@@ -11,11 +11,11 @@
         "uiSelector": true,
         "overviewUrl": "https://www.miruro.tv/watch/139630",
         "episode": 1,
-        "nextEpUrl": "https://www.miruro.tv/watch/139630/boku-no-hero-academia-6th-season/2"
+        "nextEpUrl": "https://www.miruro.tv/watch/139630/2"
       }
     },
     {
-      "url": "https://www.miruro.tv/watch/101280/tensei-shitara-slime-datta-ken/19",
+      "url": "https://www.miruro.tv/watch/101280/19",
       "expected": {
         "sync": true,
         "title": "That Time I Got Reincarnated as a Slime",
@@ -23,11 +23,11 @@
         "uiSelector": true,
         "overviewUrl": "https://www.miruro.tv/watch/101280",
         "episode": 19,
-        "nextEpUrl": "https://www.miruro.tv/watch/101280/tensei-shitara-slime-datta-ken/20"
+        "nextEpUrl": "https://www.miruro.tv/watch/101280/20"
       }
     },
     {
-      "url": "https://www.miruro.tv/watch/104459/yuru-camp-season-2/13",
+      "url": "https://www.miruro.tv/watch/104459/13",
       "expected": {
         "sync": true,
         "title": "LAID-BACK CAMP SEASON2",

--- a/src/pages/Miruro/tests.json
+++ b/src/pages/Miruro/tests.json
@@ -3,37 +3,37 @@
   "url": "https://www.miruro.tv",
   "testCases": [
     {
-      "url": "https://www.miruro.tv/watch/139630/1",
+      "url": "https://www.miruro.tv/watch?id=139630&ep=1",
       "expected": {
         "sync": true,
         "title": "My Hero Academia Season 6",
         "identifier": "139630",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch/139630",
+        "overviewUrl": "https://www.miruro.tv/watch?id=139630",
         "episode": 1,
-        "nextEpUrl": "https://www.miruro.tv/watch/139630/2"
+        "nextEpUrl": "https://www.miruro.tv/watch?id=139630&ep=2"
       }
     },
     {
-      "url": "https://www.miruro.tv/watch/101280/19",
+      "url": "https://www.miruro.tv/watch?id=101280&ep=19",
       "expected": {
         "sync": true,
         "title": "That Time I Got Reincarnated as a Slime",
         "identifier": "101280",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch/101280",
+        "overviewUrl": "https://www.miruro.tv/watch?id=101280",
         "episode": 19,
-        "nextEpUrl": "https://www.miruro.tv/watch/101280/20"
+        "nextEpUrl": "https://www.miruro.tv/watch?id=101280&ep=20"
       }
     },
     {
-      "url": "https://www.miruro.tv/watch/104459/13",
+      "url": "https://www.miruro.tv/watch?id=104459&ep=13",
       "expected": {
         "sync": true,
         "title": "LAID-BACK CAMP SEASON2",
         "identifier": "104459",
         "uiSelector": true,
-        "overviewUrl": "https://www.miruro.tv/watch/104459",
+        "overviewUrl": "https://www.miruro.tv/watch?id=104459",
         "episode": 13,
         "nextEpUrl": ""
       }


### PR DESCRIPTION
Hi,
Episode detection had stopped working in Malsync after Miruro.tv made changes to their URL for video players.
eg. 
from: https://www.miruro.tv/watch/101280/tensei-shitara-slime-datta-ken/20 
to: https://www.miruro.tv/watch/101280/20

the episode numbers are taken from url itself, so that logic had to be changed.

Best Regards,
Debjoy