### PR TITLE
Override content security policy in manifest

### DIFF
--- a/webpackConfig/webextension.assets.js
+++ b/webpackConfig/webextension.assets.js
@@ -126,6 +126,9 @@ const generateManifest = () => {
       } : {
         service_worker: 'background.js',
       },
+    content_security_policy: {
+      extension_pages: "script-src 'self'; object-src 'self';",
+    },
     action: {
       default_popup: 'popup.html',
       default_icon: 'icons/icon16.png',


### PR DESCRIPTION
Fixes #2486 

Sets `content_security_policy` to ensure all browsers use the same policy. Removes `upgrade-insecure-requests` from Firefox to allow making requests over HTTP.