### PR TITLE
Use optional permissions in firefox

### DIFF
--- a/webpackConfig/webextension.assets.js
+++ b/webpackConfig/webextension.assets.js
@@ -174,12 +174,7 @@ const generateManifest = () => {
     "optional_permissions": [
       "scripting",
     ],
-    host_permissions: [
-      ...httpPermissionsJson,
-      ...(appTarget === 'firefox' ? [
-        "<all_urls>",
-      ] : []),
-    ],
+    host_permissions: httpPermissionsJson,
     "optional_host_permissions": [
       "*://*/*",
     ],


### PR DESCRIPTION
Since Firefox 128 optional permissions are taken into account