### PR TITLE
Fix malsync ui styling issue on info page [Miruro]

### DIFF
--- a/src/pages/Miruro/style.less
+++ b/src/pages/Miruro/style.less
@@ -35,6 +35,7 @@
   background-color: var(--global-div-tr);
   padding: 0.75rem;
   margin: 0;
+  width: 100%;
 
   select {
     padding: 0.5rem;


### PR DESCRIPTION
Hi,
Very small change, literally two word one line. 
Css adjustment done for malsync ui on the Info Page for Miruro website.

Before: 
![image](https://github.com/user-attachments/assets/33113c74-0e58-4f50-8231-acda5a4701f3)
After:
![image](https://github.com/user-attachments/assets/0ee22d02-f4a1-4f7f-b224-6e893de33b5f)

Best Regards,
Debjoy