### PR TITLE
Add support for Disney Plus

### DIFF
--- a/src/pages/DisneyPlus/main.ts
+++ b/src/pages/DisneyPlus/main.ts
@@ -1,0 +1,325 @@
+import { ScriptProxy } from '../../utils/scriptProxy';
+import { pageInterface } from '../pageInterface';
+import { DisneyPlusProxyData, FoundEntry, JikanEntry, JikanEpisode } from './types';
+
+// Settings
+const searchFirstXids = 5;
+const similarityThreshold = 0.9;
+const titleTypePreference = ['English', 'Synonym', 'Default', 'Japanese'];
+const rateLimitMs = 750;
+const debug = true;
+
+const proxy = new ScriptProxy('DisneyPlus');
+const logger = con.m('D+', '#0072d2');
+
+let proxyData: DisneyPlusProxyData | undefined;
+let foundEntry: FoundEntry | undefined;
+
+export const DisneyPlus: pageInterface = {
+  name: 'DisneyPlus',
+  domain: 'https://disneyplus.com',
+  languages: ['Many'],
+  type: 'anime',
+  isSyncPage(url) {
+    return url.includes('/play/');
+  },
+  isOverviewPage(_) {
+    return false;
+  },
+  sync: {
+    getTitle(_) {
+      return foundEntry!.title;
+    },
+    getIdentifier: function (_) {
+      if (foundEntry?.mal_id !== -1) return foundEntry!.mal_id.toString();
+      return proxyData!.seriesId;
+    },
+    getOverviewUrl: function (_) {
+      return 'https://www.disneyplus.com/browse/entity-' + proxyData!.seriesId;
+    },
+    getEpisode: function (_) {
+      return foundEntry!.episodeNumber;
+    },
+    nextEpUrl: function (_) {
+      return 'https://www.disneyplus.com/play/' + proxyData!.nextEpisodeId;
+    },
+  },
+  // Structure inspired by Miruro page
+  init: async function (page) {
+    api.storage.addStyle(
+      require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
+    );
+
+    await proxy.injectScript();
+
+    let interval: NodeJS.Timer;
+
+    j.$(ready);
+    utils.urlChangeDetect(() => {
+      proxyData = undefined;
+      foundEntry = undefined;
+      j.$(ready);
+    });
+
+    function ready() {
+      page.reset();
+      if (
+        !DisneyPlus.isSyncPage(window.location.href) &&
+        !DisneyPlus.isOverviewPage!(window.location.href)
+      )
+        return;
+      clearInterval(interval);
+      interval = utils.waitUntilTrue(
+        () => {
+          if (DisneyPlus.isSyncPage(window.location.href)) {
+            proxy.getData().then(data => {
+              proxyData = data;
+            });
+
+            return $('.title-field span').text() !== '' && proxyData !== undefined;
+          } else {
+            return DisneyPlus.overview!.getTitle(window.location.href) !== '';
+          }
+        },
+        async () => {
+          foundEntry = await findEntryByTitleAndEpisodeTitle(
+            $('.title-field span').text(),
+            $('.subtitle-field span').text(),
+          );
+
+          logger.log(`Found entry: ${foundEntry.title}, episode ${foundEntry.episodeNumber}`);
+
+          page.handlePage();
+        },
+        500,
+      );
+    }
+  },
+};
+
+async function findEntryByTitleAndEpisodeTitle(
+  title: string,
+  episodeTitle: string,
+): Promise<FoundEntry> {
+  title = removeRepetition(title);
+  const entries = (await getEntriesByTitle(title))?.slice(0, searchFirstXids);
+
+  // Fall back to given title and try to extract episode number from episode title
+  const fallback = {
+    title: title,
+    mal_id: -1,
+    episodeNumber: extractEpisodeNumber(episodeTitle),
+  };
+
+  if (entries == null) {
+    logger.error('Could not get entries from Jikan for title:', title);
+    return fallback;
+  }
+
+  for (let i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    let currentPage = 1;
+
+    while (true) {
+      let data = await getEpisodesByMalId(entry.mal_id);
+      if (data == null) {
+        logger.error(`Could not get episodes for ${getBestTitle(entry)}, id ${entry.mal_id}`);
+        return fallback;
+      }
+
+      let { episodes, hasNext } = data;
+
+      for (var episode of episodes) {
+        // D+ title looks like "Episode X", while MAL title does not, skip this entry
+        if (hasEpisodePattern(episodeTitle) && !hasEpisodePattern(episode.title)) {
+          break;
+        }
+
+        let cleanedEpisodeTitle = cleanTitle(episodeTitle);
+        let jikanTitle = cleanTitle(episode.title);
+        let jikanTitleRomanji = cleanTitle(episode.title_romanji ?? '');
+
+        if (
+          jaroWinkler(cleanedEpisodeTitle, jikanTitle) > similarityThreshold ||
+          jaroWinkler(cleanedEpisodeTitle, jikanTitleRomanji) > similarityThreshold
+        ) {
+          return {
+            title: getBestTitle(entry),
+            mal_id: entry.mal_id,
+            episodeNumber: episode.mal_id,
+          };
+        }
+      }
+
+      if (hasNext) {
+        currentPage++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  logger.error('Did not find matching entry, use fallback instead');
+  return fallback;
+}
+
+async function getEntriesByTitle(title: string): Promise<JikanEntry[] | null> {
+  const res = await fetchWithRateLimit(
+    `https://api.jikan.moe/v4/anime?q=${encodeURIComponent(title)}`,
+  );
+
+  if (!res.ok) return null;
+
+  let json = await res.json();
+  return json['data'];
+}
+
+async function getEpisodesByMalId(
+  id: number,
+): Promise<{ episodes: JikanEpisode[]; hasNext: boolean } | null> {
+  const res = await fetchWithRateLimit(`https://api.jikan.moe/v4/anime/${id}/episodes`);
+  if (!res.ok) return null;
+
+  let json = await res.json();
+
+  return {
+    episodes: json['data'],
+    hasNext: json['pagination']['has_next_page'],
+  };
+}
+
+function cleanTitle(title: string): string {
+  title = title.replace(/^S\d+:E\d+\s*/, ''); // Remove leading S1E11
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, '') // Remove special characters
+    .replace(/\s+/g, '')
+    .trim();
+}
+
+/**
+ * Calculates Jaro-Winkler similarity between two strings.
+ * Higher score indicates greater similarity (range: 0.0 to 1.0).
+ */
+function jaroWinkler(s1: string, s2: string): number {
+  if (s1 == '' || s2 == '') return 0;
+  if (s1 == s2) return 1;
+
+  const m = (s1: string, s2: string): number => {
+    const s1Len = s1.length;
+    const s2Len = s2.length;
+    const matchDistance = Math.floor(Math.max(s1Len, s2Len) / 2) - 1;
+
+    const s1Matches = Array(s1Len).fill(false);
+    const s2Matches = Array(s2Len).fill(false);
+
+    let matches = 0;
+    for (let i = 0; i < s1Len; i++) {
+      const start = Math.max(0, i - matchDistance);
+      const end = Math.min(i + matchDistance + 1, s2Len);
+
+      for (let j = start; j < end; j++) {
+        if (s2Matches[j] || s1[i] !== s2[j]) continue;
+        s1Matches[i] = s2Matches[j] = true;
+        matches++;
+        break;
+      }
+    }
+
+    if (matches === 0) return 0;
+
+    let t = 0;
+    let k = 0;
+    for (let i = 0; i < s1Len; i++) {
+      if (!s1Matches[i]) continue;
+      while (!s2Matches[k]) k++;
+      if (s1[i] !== s2[k]) t++;
+      k++;
+    }
+
+    t /= 2;
+
+    return (matches / s1Len + matches / s2Len + (matches - t) / matches) / 3;
+  };
+
+  const l = Math.min(4, Math.min(s1.length, s2.length));
+  const p = 0.1; // Scaling factor for common prefix
+  const j = m(s1, s2);
+
+  const prefix = Array.from({ length: l }).reduce<number>(
+    (acc, _, i) => (s1[i] === s2[i] ? acc + 1 : acc),
+    0,
+  );
+
+  return j + prefix * p * (1 - j);
+}
+
+function hasEpisodePattern(title: string): boolean {
+  const episodeRegex = /Episode\s\d+/i;
+  return episodeRegex.test(title);
+}
+
+function extractEpisodeNumber(title: string): number {
+  // 1. Episode 1
+  const episodeRegex = /^(\d+)\.\s(?:Episode\s(\d+)|.+)$/i;
+  const match = title.match(episodeRegex);
+
+  if (match) {
+    return match[2] ? parseInt(match[2], 10) : parseInt(match[1], 10);
+  }
+
+  // S1:E11 ...
+  const match2 = title.match(/S(\d+):E(\d+)/);
+
+  if (match2) {
+    const season = parseInt(match2[1], 10);
+    const episode = parseInt(match2[2], 10);
+    return episode;
+  }
+
+  return 0;
+}
+
+function getBestTitle(entry: JikanEntry): string {
+  for (const type of titleTypePreference) {
+    const title = entry.titles.find(item => item.type === type);
+    if (title) return title.title;
+  }
+
+  return entry.titles[0].title;
+}
+
+let lastRequestTime = 0;
+
+async function fetchWithRateLimit(url: string): Promise<any> {
+  const now = Date.now();
+  const timeSinceLastRequest = now - lastRequestTime;
+
+  if (timeSinceLastRequest < rateLimitMs) {
+    await utils.wait(rateLimitMs - timeSinceLastRequest);
+  }
+
+  lastRequestTime = Date.now();
+
+  const res = await fetch(url);
+
+  return res;
+}
+
+function removeRepetition(title: string): string {
+  const length = title.length;
+
+  for (let i = 1; i <= length / 2; i++) {
+    const pattern = title.slice(0, i);
+    const repeated = new RegExp(`^(${pattern})+`);
+
+    if (repeated.test(title)) {
+      const match = title.match(repeated);
+      if (match && match[0] === title) {
+        return pattern;
+      }
+    }
+  }
+
+  return title;
+}

--- a/src/pages/DisneyPlus/main.ts
+++ b/src/pages/DisneyPlus/main.ts
@@ -7,7 +7,6 @@ const searchFirstXids = 5;
 const similarityThreshold = 0.9;
 const titleTypePreference = ['English', 'Synonym', 'Default', 'Japanese'];
 const rateLimitMs = 750;
-const debug = true;
 
 const proxy = new ScriptProxy('DisneyPlus');
 const logger = con.m('D+', '#0072d2');

--- a/src/pages/DisneyPlus/meta.json
+++ b/src/pages/DisneyPlus/meta.json
@@ -1,0 +1,7 @@
+{
+  "search": "https://www.disneyplus.com/browse/search",
+  "searchDatabase": "DisneyPlus",
+  "urls": {
+    "match": ["*://www.disneyplus.com/*"]
+  }
+}

--- a/src/pages/DisneyPlus/proxy.ts
+++ b/src/pages/DisneyPlus/proxy.ts
@@ -1,0 +1,88 @@
+import { DisneyPlusProxyData } from './types';
+
+// Inspired by HiDive proxy
+export function script() {
+  const logger = con.m('D+ Proxy');
+  const auth = '';
+  if (!(window as any).fetchOverride) {
+    (window as any).malsyncData = {};
+    // eslint-disable-next-line no-var
+    var originalFetch = fetch;
+    // @ts-ignore
+    // eslint-disable-next-line no-global-assign
+    fetch = (input, init) =>
+      originalFetch(input, init).then(response => {
+        try {
+          const url = input.url || input;
+
+          if (url.includes('disney.api')) {
+            const res = response.clone();
+            res.json().then(data => {
+              logger.log('Fetch request', this._url, data);
+            });
+          }
+        } catch (e) {
+          logger.error('MALSYNC', e);
+        }
+
+        return response;
+      });
+
+    class CustomXMLHttpRequest extends XMLHttpRequest {
+      _url: string | undefined;
+
+      constructor() {
+        super();
+      }
+
+      open(
+        method: string,
+        url: string,
+        async: boolean = true,
+        user?: string | undefined,
+        password?: string | undefined,
+      ) {
+        this._url = url;
+        super.open.apply(this, [method, url, async, user, password]);
+      }
+
+      send(body?: any) {
+        const originalOnReadyStateChange = this.onreadystatechange;
+
+        this.onreadystatechange = ev => {
+          if (this.readyState === XMLHttpRequest.DONE) {
+            // logger.log('XMLHttpRequest', this._url, this.responseText);
+            if (this._url?.includes('/deeplink')) {
+              try {
+                let json = JSON.parse(this.responseText);
+                let temp = json['data']['deeplink']['actions'][0];
+                let data: DisneyPlusProxyData = {
+                  seriesId: temp['partnerFeed']['evaSeriesEntityId'],
+                  nextEpisodeId: temp['upNextId'],
+                  title: temp['internalTitle'],
+                };
+                (window as any).malsyncData = data;
+              } catch (e) {
+                logger.error(e);
+              }
+            }
+          }
+
+          if (originalOnReadyStateChange) {
+            originalOnReadyStateChange.apply(this, [ev]);
+          }
+        };
+
+        super.send.apply(this, [body]);
+      }
+    }
+
+    window.XMLHttpRequest = CustomXMLHttpRequest as any;
+    (window as any).fetchOverride = true;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(window as any, 'malsyncData')) {
+    return (window as any).malsyncData;
+  }
+  return undefined;
+}

--- a/src/pages/DisneyPlus/readme.md
+++ b/src/pages/DisneyPlus/readme.md
@@ -1,0 +1,108 @@
+# Disney Plus
+
+Implementing this extension has been difficult since there is very little consistency in the way D+ shows their content.
+
+## Anime on D+
+
+<details>
+  <summary>Full description of each anime</summary>
+- BLEACH: Thousand-Year Blood War  
+  Consolidates all seasons into a single entry
+  1.  Season 1: Bleach: Thousand-Year Blood War : `Bleach: Sennen Kessen-hen`
+  2.  Season 2: Bleach: Thousand-Year Blood War - The separation : `Bleach: Sennen Kessen-hen - Ketsubetsu-tan`
+  3.  Season 3: Bleach: Thousand-Year Blood War - The Conflict : `Bleach: Sennen Kessen-hen - Soukoku-tan`  
+      Episode titles do seem to match
+- Bleach  
+  Arbitrary seasons that do not exist on MAL  
+  Episode names contain their number, counts through all seasons
+- (Marvel) Future Avengers  
+  Only season 2 is present, I have added the episodes into MAL (pending approval)
+- Tokyo Revengers  
+  Only contains a season 2, which is 2 entries combined:
+
+1. `Tokyo Revengers: Christmas Showdown` | `Tokyo Revengers: Seiya Kessen-hen` (1-13)
+2. `Tokyo Revengers: Tenjiku Arc` | `Tokyo Revengers: Tenjiku-hen` (14-26)
+
+The episode names do match
+
+- Mission: Yozakura Family  
+  Contains everything  
+  Has correct numbering and episode titles
+- Tengoku Daimakyo (Heavenly Delusion)  
+  Contains everything  
+  Has correct numbering and episode titles
+- Ishura  
+  Contains everything  
+  Has correct numbering and episode titles
+- Undead Unluck  
+  Contains everything  
+  Has correct numbering and episode titles
+- Go! Go! Loser Ranger!  
+  Contains everything  
+  Has correct numbering and episode titles
+- The Fable  
+  Contains everything  
+  Has correct numbering and episode titles
+- Murai In Love  
+  Contains everything  
+  Has correct numbering and episode titles
+- Summer Time Rendering  
+  Contains everything  
+  Has correct numbering and episode titles
+- Code Geass: Rozé of the Recapture  
+  Contains everything  
+  Has correct numbering and episode titles
+- The Tatami Time Machine Blues  
+  Contains everything  
+  Has correct numbering and episode titles
+- Sand Land: The Series  
+  Contains everything  
+  Names mostly match (the end is the same)
+- Star Wars: Visions  
+  Contains everything  
+  Has correct numbering and episode titles  
+  Has a season 2 which is not on MAL
+- BLACK ROCK SHOOTER DOWNFALL  
+  Title differs slightly: `Black★★Rock Shooter: Dawn Fall`  
+  Contains all episodes, correct numbering and correct titles
+- Synduality Noir  
+  Has seasons 1/2 merged (`Synduality: Noir Part 2`)
+  Episode numbers reset in S2  
+  Episode titles are correct
+- Phoenix: Eden17  
+ Has everything  
+ Episode numbers and titles are correct
+</details>
+
+| Title                                | Correct title                                       | Contains Everything                    | Split seasons | Merged seasons | Correct episode titles | Correct episode number in title           |
+| ------------------------------------ | --------------------------------------------------- | -------------------------------------- | ------------- | -------------- | ---------------------- | ----------------------------------------- |
+| Bleach: Thousand-Year Blood War      | No: Merges entries                                  | Yes                                    | No            | Yes            | Yes                    | Yes (restarts per season)                 |
+| Bleach                               | Yes                                                 | Yes                                    | Yes           | No             | No                     | Yes (continues through arbitrary seasons) |
+| Future Avengers                      | No: `Marvel Future Avengers`                        | Only S2                                | No            | No             | Pending approval       | Yes                                       |
+| Tokyo Revengers                      | No: Merges entries                                  | Only S2                                | No            | Yes            | Yes                    | Yes (restarts per arc)                    |
+| Mission: Yozakura Family             | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Tengoku Daimakyo (Heavenly Delusion) | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Ishura                               | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Undead Unluck                        | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Go! Go! Loser Ranger!                | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| The Fable                            | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Murai In Love                        | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Summer Time Rendering                | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Code Geass: Rozé of the Recapture    | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| The Tatami Time Machine Blues        | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Sand Land: The Series                | Yes                                                 | Yes                                    | No            | No             | Mostly                 | Yes                                       |
+| Star Wars: Visions                   | Yes                                                 | Yes (also has S2, which is not on MAL) | No            | No             | Yes                    | Yes                                       |
+| BLACK ROCK SHOOTER DOWNFALL          | Slight difference: `Black★★Rock Shooter: Dawn Fall` | Yes                                    | No            | No             | Yes                    | Yes                                       |
+| Synduality Noir                      | Yes                                                 | Yes                                    | No            | Yes            | Yes                    | No (resets in S2)                         |
+| Phoenix: Eden17                      | Yes                                                 | Yes                                    | No            | No             | Yes                    | Yes                                       |
+|                                      | 16/19                                               | 17/19                                  | 1/19          | 3/19           | 17/19                  | 18/19                                     |
+
+## Approach
+
+Since not all entries have an exact title match, use Jikan API instead:
+
+1. Search Jikan based on the given title
+2. Get the episode list of the top X results
+3. Traverse the episode list and find a title match (string similarity to account for slight changes)
+4. When a match is found, this gives the correct MAL entry and it's episode number
+5. When no match is found this way, revert to given title and episode number, depend on MalSync corrections if these are not correct

--- a/src/pages/DisneyPlus/style.less
+++ b/src/pages/DisneyPlus/style.less
@@ -1,0 +1,13 @@
+@import './../pages';
+
+@textColor: white;
+
+.miniMAL-Fullscreen,
+.miniMAL-hide {
+  .open-info-popup.floatbutton,
+  #flashinfo-div,
+  #flash-div-bottom,
+  #flash-div-top {
+    display: none !important;
+  }
+}

--- a/src/pages/DisneyPlus/tests.json
+++ b/src/pages/DisneyPlus/tests.json
@@ -1,0 +1,42 @@
+{
+  "title": "DisneyPlus",
+  "url": "https://www.disneyplus.com",
+  "testCases": [
+    {
+      "url": "https://www.disneyplus.com/browse/entity-c649c634-7f8d-48a9-ba72-48bd4b9c8419",
+      "expected": {
+        "sync": false,
+        "title": "Bleach",
+        "identifier": "c649c634-7f8d-48a9-ba72-48bd4b9c8419"
+      }
+    },
+    {
+      "url": "https://www.disneyplus.com/play/75b4caf7-22d4-4683-afc4-c643863cb1e7",
+      "expected": {
+        "sync": true,
+        "title": "Bleach",
+        "identifier": "c649c634-7f8d-48a9-ba72-48bd4b9c8419",
+        "episode": 21,
+        "nextEpUrl": "https://www.disneyplus.com/play/87ba0c20-9e8e-4db1-9bde-2a354df69f3f"
+      }
+    },
+    {
+      "url": "https://www.disneyplus.com/browse/entity-9a14d04d-01f2-40d0-be62-a6c8ffe24137",
+      "expected": {
+        "sync": false,
+        "title": "Undead Unluck",
+        "identifier": "9a14d04d-01f2-40d0-be62-a6c8ffe24137"
+      }
+    },
+    {
+      "url": "https://www.disneyplus.com/play/65e19f8d-2255-4e99-9c48-acdc0c136067",
+      "expected": {
+        "sync": true,
+        "title": "Undead Unluck",
+        "identifier": "9a14d04d-01f2-40d0-be62-a6c8ffe24137",
+        "episode": 23,
+        "nextEpUrl": "https://www.disneyplus.com/play/fb48dfd8-100c-464e-bf78-de245097bba0"
+      }
+    }
+  ]
+}

--- a/src/pages/DisneyPlus/types.ts
+++ b/src/pages/DisneyPlus/types.ts
@@ -1,0 +1,26 @@
+export interface JikanEntry {
+  mal_id: number;
+  url: string;
+  titles: {
+    type: string;
+    title: string;
+  }[];
+}
+
+export interface JikanEpisode {
+  mal_id: number;
+  title: string;
+  title_romanji: string | null;
+}
+
+export interface FoundEntry {
+  title: string;
+  episodeNumber: number;
+  mal_id: number;
+}
+
+export interface DisneyPlusProxyData {
+  seriesId: string;
+  nextEpisodeId: string;
+  title: string;
+}

--- a/src/pages/list.json
+++ b/src/pages/list.json
@@ -35,6 +35,11 @@
     "name": "Netflix"
   },
   {
+    "domain": "https://disneyplus.com",
+    "type": "anime",
+    "name": "DisneyPlus"
+  },
+  {
     "domain": "https://animeflv.net",
     "type": "anime",
     "name": "Animeflv"

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -133,8 +133,10 @@ import { TempleScan } from './TempleScan/main';
 import { ScyllaScans } from './ScyllaScans/main';
 import { VortexScans } from './VortexScans/main';
 import { AnimeLib } from './AnimeLib/main';
+import { DisneyPlus } from './DisneyPlus/main';
 
 export const pages = {
+  DisneyPlus,
   Crunchyroll,
   Mangadex,
   Gogoanime,


### PR DESCRIPTION
I done my best to add support for Disney Plus, using the Jikan API to make up for any inconsistencies in how D+ represents it's data.

Some aspects are configurable, for which the settings can be found at the top of `src\pages\DisneyPlus\main.ts`.  
These settings are:
- How many Jikan entries to search for a matching episode name
- How similar the episode name must be for it to be considered a match (using Jaro-Winkler distance)
- Which type of title should be preferable returned: `English`, `Synonym`, `Default` or `Japanese`
- The minimum delay between two requests to Jikan