### PR TITLE
Fixed incorrected locale codes (pt-BR, zh-CN) + tests

### DIFF
--- a/assets/_locales/pt_BR/messages.json
+++ b/assets/_locales/pt_BR/messages.json
@@ -1536,7 +1536,7 @@
         }
     },
     "locale": {
-        "message": "pt_BR",
+        "message": "pt-BR",
         "description": "Current locale"
     }
 }

--- a/assets/_locales/zh_CN/messages.json
+++ b/assets/_locales/zh_CN/messages.json
@@ -1014,7 +1014,7 @@
         "description": "Info table on overview - Total Playtime: 276 mins"
     },
     "locale": {
-        "message": "zh_CN",
+        "message": "zh-CN",
         "description": "Current locale"
     }
 }

--- a/test/src/assets/_locales/locales.test.ts
+++ b/test/src/assets/_locales/locales.test.ts
@@ -1,0 +1,46 @@
+import { assert, expect } from 'chai';
+import * as fs from 'fs'
+
+describe('Validating locales', function() {
+  const dir = './assets/_locales';
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir);
+  } catch (err) {
+    assert.fail(`Failed to read ${dir}: ${err.message}`);
+  }
+
+  files.forEach(folder => {
+    it(folder, function() {
+      try {
+        const file = `${dir}/${folder}/messages.json`;
+        
+        if (!fs.existsSync(file)) {
+          assert.fail(`messages.json not found in ${folder}`);
+        }
+
+        let content;
+        try {
+          content = JSON.parse(fs.readFileSync(file, 'utf8'));
+        } catch (parseError) {
+          assert.fail(`Invalid JSON in ${folder}/messages.json: ${parseError.message}`);
+        }
+
+        if (!content || !content.locale || !content.locale.message) {
+          assert.fail(`Missing 'locale.message' field in ${file}`);
+        }
+
+        const locale = content.locale.message;
+        try {
+          const formattedDate = new Date().toLocaleDateString(locale);
+          expect(formattedDate).to.be.a('string');
+          assert.ok(true, `${locale}' is valid`);
+        } catch (localeError) {
+          assert.fail(`Invalid locale '${locale}' in ${file}: ${localeError.message}`);
+        }
+      } catch (error) {
+        assert.fail(`Error while processing ${folder}: ${error.message}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Quick fix for "Incorrected locale information provided" error while using pt-BR + zh-CN locales in browser/extension
* pt_BR -> pt-BR
* zh_CN -> zh-CN

Also made tests in case of adding new locale in the future.
Until this is released there're these "fixes" for anyone using Brazilian Portuguese or Chinese:
* Revert to older version of extension from https://github.com/MALSync/MALSync/releases/tag/0.10.4
* Change browser language to OTHER than Brazilian Portuguese or Chinese
* Use "Force English" setting in Settings/Miscellaneous