### PR TITLE
Fallback to other sync modes

### DIFF
--- a/assets/_locales/de/messages.json
+++ b/assets/_locales/de/messages.json
@@ -627,6 +627,10 @@
         "message": "Modus",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Authentifizieren",
         "description": "Authenticate"

--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -823,6 +823,10 @@
         "message": "Mode",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Authenticate",
         "description": "Authenticate"

--- a/assets/_locales/es/messages.json
+++ b/assets/_locales/es/messages.json
@@ -627,6 +627,10 @@
         "message": "Modo",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Autenticar",
         "description": "Authenticate"

--- a/assets/_locales/fr/messages.json
+++ b/assets/_locales/fr/messages.json
@@ -627,6 +627,10 @@
         "message": "Mode",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Se connecter",
         "description": "Authenticate"

--- a/assets/_locales/id/messages.json
+++ b/assets/_locales/id/messages.json
@@ -605,6 +605,10 @@
         "message": "Sumber",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Otentikasi",
         "description": "Authenticate"

--- a/assets/_locales/ms/messages.json
+++ b/assets/_locales/ms/messages.json
@@ -605,6 +605,10 @@
         "message": "Mod",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Pengesahan",
         "description": "Authenticate"

--- a/assets/_locales/nl/messages.json
+++ b/assets/_locales/nl/messages.json
@@ -627,6 +627,10 @@
         "message": "Mode",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Authenticatie",
         "description": "Authenticate"

--- a/assets/_locales/pl/messages.json
+++ b/assets/_locales/pl/messages.json
@@ -609,6 +609,10 @@
         "message": "Tryb",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Uwierzytelnij",
         "description": "Authenticate"

--- a/assets/_locales/pt_BR/messages.json
+++ b/assets/_locales/pt_BR/messages.json
@@ -627,6 +627,10 @@
         "message": "Modo",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Autenticar",
         "description": "Authenticate"

--- a/assets/_locales/tr/messages.json
+++ b/assets/_locales/tr/messages.json
@@ -525,6 +525,10 @@
         "message": "Mod",
         "description": "Mode"
     },
+    "settings_Fallback": {
+        "message": "Fallback to other modes",
+        "description": "Fallback to other modes"
+    },
     "settings_Authenticate": {
         "message": "Doğrulama",
         "description": "Authenticate"

--- a/src/_minimal/components/settings/settings-structure-tracking.ts
+++ b/src/_minimal/components/settings/settings-structure-tracking.ts
@@ -56,6 +56,19 @@ export const trackingSimple: ConfObj[] = [
     component: SettingsGeneral,
   },
   {
+    key: 'syncFallback',
+    title: () => api.storage.lang('settings_Fallback'),
+    change: () => {
+      utils.clearCache();
+      if (api.type === 'webextension') localStore.clear();
+    },
+    props: {
+      component: 'checkbox',
+      option: 'syncFallback',
+    },
+    component: SettingsGeneral,
+  },
+  {
     key: 'syncModeSimkl',
     title: () => `${api.storage.lang('Manga')} ${api.storage.lang('settings_Mode')}`,
     condition: () => api.settings.get('syncMode') === 'SIMKL',

--- a/src/_provider/Combined/helper.ts
+++ b/src/_provider/Combined/helper.ts
@@ -1,0 +1,9 @@
+export function getSyncMode(type = '') {
+  const mode = api.settings.get('syncMode');
+  //
+  if (mode === 'SIMKL' && (type === 'manga' || type.indexOf('/manga/') !== -1)) {
+    return api.settings.get('syncModeSimkl');
+  }
+  //
+  return mode;
+}

--- a/src/_provider/Combined/list.ts
+++ b/src/_provider/Combined/list.ts
@@ -1,0 +1,91 @@
+import { ListAbstract } from '../listAbstract';
+import * as helper from './helper';
+import { UserList as MalList } from '../MyAnimeList_hybrid/list';
+import { UserList as MalApiList } from '../MyAnimeList_api/list';
+import { UserList as AnilistList } from '../AniList/list';
+import { UserList as KitsuList } from '../Kitsu/list';
+import { UserList as SimklList } from '../Simkl/list';
+import { UserList as ShikiList } from '../Shikimori/list';
+// import { UserList as LocalList } from '../Local/list';
+
+export class UserList extends ListAbstract {
+  name = 'combined';
+
+  authenticationUrl = '';
+
+  private syncMode: string;
+
+  private lists: Record<string, ListAbstract>;
+
+  private order: string[];
+
+  private cacheKeys = new Set<any>();
+
+  constructor(
+    protected status: number = 1,
+    protected listType: 'anime' | 'manga' = 'anime',
+    protected sort: string = 'default',
+  ) {
+    super(status, listType, sort);
+    this.syncMode = helper.getSyncMode(listType);
+    this.lists = {
+      MAL: new MalList(status, listType, sort),
+      MALAPI: new MalApiList(status, listType, sort),
+      ANILIST: new AnilistList(status, listType, sort),
+      KITSU: new KitsuList(status, listType, sort),
+      SIMKL: new SimklList(status, listType, sort),
+      SHIKI: new ShikiList(status, listType, sort),
+      // LOCAL: new LocalList(status, listType, sort),
+    };
+    this.name = this.lists[this.syncMode].name;
+    this.authenticationUrl = (this.lists[this.syncMode] as UserList).authenticationUrl;
+    this.order = [this.syncMode];
+    for (const mode in this.lists) {
+      this.order.push(mode);
+    }
+    return this;
+  }
+
+  async getUserObject() {
+    return this.lists[this.syncMode].getUserObject();
+  }
+
+  _getSortingOptions() {
+    return [];
+  }
+
+  async getPart() {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (this.offset >= this.order.length) {
+        this.done = true;
+        return [];
+      }
+      const mode = this.order[this.offset];
+      const list = this.lists[mode];
+      con.log(
+        '[UserList][Combined]',
+        `status: ${this.status}`,
+        `syncMode: ${this.syncMode}`,
+        `mode: ${mode}`,
+      );
+      try {
+        const part = await list.getPart().then(part =>
+          part.filter(item => {
+            const result = !this.cacheKeys.has(item.cacheKey);
+            this.cacheKeys.add(item.cacheKey);
+            return result;
+          }),
+        );
+        if (list.isDone()) {
+          this.offset++;
+          this.done = this.offset >= this.order.length;
+        }
+        return part;
+      } catch (e) {
+        this.offset++;
+        con.error(e);
+      }
+    }
+  }
+}

--- a/src/_provider/Combined/search.ts
+++ b/src/_provider/Combined/search.ts
@@ -1,0 +1,34 @@
+import { search as malSearch } from '../MyAnimeList_hybrid/search';
+import { search as malApiSearch } from '../MyAnimeList_api/search';
+import { search as anilistSearch } from '../AniList/search';
+import { search as kitsuSearch } from '../Kitsu/search';
+import { search as simklSearch } from '../Simkl/search';
+import { search as shikiSearch } from '../Shikimori/search';
+import { searchInterface } from '../definitions';
+import * as helper from './helper';
+
+const searches: Record<string, searchInterface> = {
+  MAL: malSearch,
+  MALAPI: malApiSearch,
+  ANILIST: anilistSearch,
+  KITSU: kitsuSearch,
+  SIMKL: simklSearch,
+  SHIKI: shikiSearch,
+};
+
+export const search: searchInterface = async function (
+  keyword,
+  type: 'anime' | 'manga',
+  options = {},
+  sync = false,
+) {
+  const syncMode: string = helper.getSyncMode(type);
+  const promise = searches[syncMode](keyword, type, options, sync);
+  return Promise.all(
+    Object.entries(searches).map(([mode, search]) =>
+      mode === syncMode
+        ? Promise.resolve([])
+        : search(keyword, type, options, sync).catch(() => []),
+    ),
+  ).then(value => promise.then(result => result.concat(value.flat())));
+};

--- a/src/_provider/listFactory.ts
+++ b/src/_provider/listFactory.ts
@@ -7,6 +7,7 @@ import { UserList as KitsuList } from './Kitsu/list';
 import { UserList as SimklList } from './Simkl/list';
 import { UserList as ShikiList } from './Shikimori/list';
 import { UserList as LocalList } from './Local/list';
+import { UserList as CombinedList } from './Combined/list';
 
 export async function getList(...args) {
   let tempList: listElement[] = [];
@@ -37,6 +38,9 @@ function getListObj(args, syncMode = '') {
 
   const [status, listType, sorting] = args;
 
+  if (api.settings.get('syncFallback')) {
+    return new CombinedList(status, listType, sorting);
+  }
   if (syncMode === 'MAL') {
     return new MalList(status, listType, sorting);
   }

--- a/src/_provider/metaDataFactory.ts
+++ b/src/_provider/metaDataFactory.ts
@@ -6,6 +6,11 @@ import { MetaOverview as AniMeta } from './AniList/metaOverview';
 import { MetaOverview as KitsuMeta } from './Kitsu/metaOverview';
 import { MetaOverview as SimklMeta } from './Simkl/metaOverview';
 import { MetaOverview as ShikiMeta } from './Shikimori/metaOverview';
+import { Single as MalSingle } from './MyAnimeList_hybrid/single';
+import { Single as SnilistSingle } from './AniList/single';
+import { Single as SitsuSingle } from './Kitsu/single';
+import { Single as SimklSingle } from './Simkl/single';
+import { Single as ShikiSingle } from './Shikimori/single';
 
 export function getOverview(url, type, syncMode = '') {
   if (!syncMode) {
@@ -15,6 +20,26 @@ export function getOverview(url, type, syncMode = '') {
   if (/^local:\/\//i.test(url)) {
     return new LocalMeta(url);
   }
+
+  if (api.settings.get('syncFallback')) {
+    const hostname = new URL(url).hostname;
+    if (hostname === 'anilist.co') {
+      return new AniMeta(url);
+    }
+    if (hostname === 'kitsu.app') {
+      return new KitsuMeta(url);
+    }
+    if (hostname === 'simkl.com') {
+      return new SimklMeta(url);
+    }
+    if (hostname === 'shikimori.one') {
+      return new ShikiMeta(url);
+    }
+    if (hostname === 'myanimelist.net') {
+      return new MalMeta(url);
+    }
+  }
+
   if (syncMode === 'ANILIST') {
     return new AniMeta(url);
   }

--- a/src/_provider/searchFactory.ts
+++ b/src/_provider/searchFactory.ts
@@ -5,6 +5,7 @@ import { search as aniSearch } from './AniList/search';
 import { search as kitsuSearch } from './Kitsu/search';
 import { search as simklSearch } from './Simkl/search';
 import { search as shikiSearch } from './Shikimori/search';
+import { search as combinedSearch } from './Combined/search';
 
 export function search(
   keyword,
@@ -17,6 +18,9 @@ export function search(
     syncMode = helper.getSyncMode(type);
   }
 
+  if (api.settings.get('syncFallback')) {
+    return combinedSearch(keyword, type, options, sync);
+  }
   if (syncMode === 'KITSU') {
     return kitsuSearch(keyword, type, options, sync);
   }

--- a/src/_provider/singleFactory.ts
+++ b/src/_provider/singleFactory.ts
@@ -13,6 +13,26 @@ export function getSingle(url: string) {
   if (/^local:\/\//i.test(url)) {
     return new LocalSingle(url);
   }
+
+  if (api.settings.get('syncFallback')) {
+    const hostname = new URL(url).hostname;
+    if (hostname === 'myanimelist.net') {
+      return new MalSingle(url);
+    }
+    if (hostname === 'anilist.co') {
+      return new SnilistSingle(url);
+    }
+    if (hostname === 'kitsu.app') {
+      return new SitsuSingle(url);
+    }
+    if (hostname === 'simkl.com') {
+      return new SimklSingle(url);
+    }
+    if (hostname === 'shikimori.one') {
+      return new ShikiSingle(url);
+    }
+  }
+
   const syncMode = helper.getSyncMode(url);
   if (syncMode === 'MAL') {
     return new MalSingle(url);

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -16,6 +16,7 @@ export const settingsObj = {
     userscriptModeButton: false,
     syncMode: 'MAL',
     syncModeSimkl: 'MAL',
+    syncFallback: true,
     localSync: true,
     delay: 0,
     videoDuration: 85,

--- a/src/pages/ADKami/main.ts
+++ b/src/pages/ADKami/main.ts
@@ -38,7 +38,7 @@ export const ADKami: pageInterface = {
     },
     getMalUrl(provider) {
       if (jsonData.mal_id) return `https://myanimelist.net/anime/${jsonData.mal_id}`;
-      if (provider === 'ANILIST') {
+      if (provider === 'ANILIST' || api.settings.get('syncFallback')) {
         if (jsonData.anilist_id) return `https://anilist.co/anime/${jsonData.anilist_id}`;
       }
       return false;

--- a/src/pages/AnimeOnsen/main.ts
+++ b/src/pages/AnimeOnsen/main.ts
@@ -36,7 +36,7 @@ export const AnimeOnsen: pageInterface = {
     getMalUrl(provider) {
       // get myanimelist anime url
       return new Promise(resolve => {
-        if (provider === 'MAL')
+        if (provider === 'MAL' || api.settings.get('syncFallback'))
           resolve(j.$('meta[name="ao-content-mal-url"]').attr('content') || false);
         else resolve(false);
       });
@@ -92,7 +92,7 @@ export const AnimeOnsen: pageInterface = {
     getMalUrl(provider) {
       // get myanimelist anime url
       return new Promise(resolve => {
-        if (provider === 'MAL')
+        if (provider === 'MAL' || api.settings.get('syncFallback'))
           resolve(j.$('meta[name="ao-content-mal-url"]').attr('content') || false);
         else resolve(false);
       });

--- a/src/pages/Animeworld/main.ts
+++ b/src/pages/Animeworld/main.ts
@@ -30,7 +30,7 @@ export const Animeworld: pageInterface = {
         return malUrl;
       }
 
-      if (provider === 'ANILIST') {
+      if (provider === 'ANILIST' || api.settings.get('syncFallback')) {
         return j.$('#anilist-button').attr('href') || false;
       }
 

--- a/src/pages/ComicK/main.ts
+++ b/src/pages/ComicK/main.ts
@@ -30,7 +30,10 @@ export const ComicK: pageInterface = {
       if (jsonData.md_comic.links) {
         if (jsonData.md_comic.links.mal)
           return `https://myanimelist.net/manga/${jsonData.md_comic.links.mal}`;
-        if (provider === 'ANILIST' && jsonData.md_comic.links.al)
+        if (
+          (provider === 'ANILIST' || api.settings.get('syncFallback')) &&
+          jsonData.md_comic.links.al
+        )
           return `https://anilist.co/manga/${jsonData.md_comic.links.al}`;
       }
       return false;
@@ -88,7 +91,7 @@ export const ComicK: pageInterface = {
     getMalUrl(provider) {
       if (jsonData.links) {
         if (jsonData.links.mal) return `https://myanimelist.net/manga/${jsonData.links.mal}`;
-        if (provider === 'ANILIST' && jsonData.links.al)
+        if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && jsonData.links.al)
           return `https://anilist.co/manga/${jsonData.links.al}`;
       }
       return false;

--- a/src/pages/Kaguya/main.ts
+++ b/src/pages/Kaguya/main.ts
@@ -52,7 +52,7 @@ export const Kaguya: pageInterface = {
       j.$('#mal-sync').first().after(j.html(selector));
     },
     async getMalUrl(provider) {
-      if (provider === 'ANILIST' && jsonData.aniId)
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && jsonData.aniId)
         return `https://anilist.co/anime/${jsonData.aniId}`;
 
       if (jsonData.aniId) {

--- a/src/pages/Kavita/main.ts
+++ b/src/pages/Kavita/main.ts
@@ -75,8 +75,10 @@ export const Kavita: pageInterface = {
     },
     getMalUrl(provider) {
       if (seriesDetails.malLink) return seriesDetails.malLink;
-      if (provider === 'ANILIST' && seriesDetails.anilistLink) return seriesDetails.anilistLink;
-      if (provider === 'KITSU' && seriesDetails.kitsuLink) return seriesDetails.kitsuLink;
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && seriesDetails.anilistLink)
+        return seriesDetails.anilistLink;
+      if ((provider === 'KITSU' || api.settings.get('syncFallback')) && seriesDetails.kitsuLink)
+        return seriesDetails.kitsuLink;
       return false;
     },
     readerConfig: [

--- a/src/pages/Kitsune/main.ts
+++ b/src/pages/Kitsune/main.ts
@@ -48,7 +48,8 @@ export const Kitsune: pageInterface = {
       } catch (e) {
         // do nothing
       }
-      if (provider === 'ANILIST') return `https://anilist.co/anime/${jsonData.anilistId}`;
+      if (provider === 'ANILIST' || api.settings.get('syncFallback'))
+        return `https://anilist.co/anime/${jsonData.anilistId}`;
       return false;
     },
   },

--- a/src/pages/Komga/main.ts
+++ b/src/pages/Komga/main.ts
@@ -64,8 +64,10 @@ export const Komga: pageInterface = {
     },
     getMalUrl(provider) {
       if (series.links.mal) return series.links.mal;
-      if (provider === 'ANILIST' && series.links.al) return series.links.al;
-      if (provider === 'KITSU' && series.links.kt) return series.links.kt;
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && series.links.al)
+        return series.links.al;
+      if ((provider === 'KITSU' || api.settings.get('syncFallback')) && series.links.kt)
+        return series.links.kt;
       return false;
     },
     readerConfig: [

--- a/src/pages/MangaFire/main.ts
+++ b/src/pages/MangaFire/main.ts
@@ -68,7 +68,7 @@ export const MangaFire: pageInterface = {
     },
     getMalUrl(provider) {
       if (jsonData.mal_id) return `https://myanimelist.net/manga/${jsonData.mal_id}`;
-      if (provider === 'ANILIST' && jsonData.anilist_id)
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && jsonData.anilist_id)
         return `https://anilist.co/manga/${jsonData.anilist_id}`;
       return false;
     },

--- a/src/pages/MangaReader/main.ts
+++ b/src/pages/MangaReader/main.ts
@@ -49,7 +49,7 @@ export const MangaReader: pageInterface = {
     },
     getMalUrl(provider) {
       if (jsonData.mal_id) return `https://myanimelist.net/manga/${jsonData.mal_id}`;
-      if (provider === 'ANILIST' && jsonData.anilist_id)
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && jsonData.anilist_id)
         return `https://anilist.co/manga/${jsonData.anilist_id}`;
       return false;
     },

--- a/src/pages/Mangadex/main.ts
+++ b/src/pages/Mangadex/main.ts
@@ -84,9 +84,9 @@ export const Mangadex: pageInterface = {
     },
     getMalUrl(provider) {
       if (mangaData.links?.mal) return `https://myanimelist.net/manga/${mangaData.links.mal}`;
-      if (provider === 'ANILIST' && mangaData.links?.al)
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && mangaData.links?.al)
         return `https://anilist.co/manga/${mangaData.links.al}`;
-      if (provider === 'KITSU' && mangaData.links?.kt)
+      if ((provider === 'KITSU' || api.settings.get('syncFallback')) && mangaData.links?.kt)
         return `https://kitsu.app/manga/${mangaData.links.kt}`;
       return false;
     },

--- a/src/pages/Miruro/main.ts
+++ b/src/pages/Miruro/main.ts
@@ -49,7 +49,7 @@ export const Miruro: pageInterface = {
     getMalUrl(provider) {
       const myanimelistBtn = j.$("a[href^='https://myanimelist.net']");
       const anilistBtn = j.$("a[href^='https://anilist.co']");
-      if (provider === 'ANILIST' && anilistBtn.length > 0) {
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && anilistBtn.length > 0) {
         return `${anilistBtn.first().attr('href')}`;
       }
       if (myanimelistBtn.length > 0) {

--- a/src/pages/Zoro/main.ts
+++ b/src/pages/Zoro/main.ts
@@ -44,7 +44,7 @@ export const Zoro: pageInterface = {
     },
     getMalUrl(provider) {
       if (jsonData.mal_id) return `https://myanimelist.net/anime/${jsonData.mal_id}`;
-      if (provider === 'ANILIST' && jsonData.anilist_id)
+      if ((provider === 'ANILIST' || api.settings.get('syncFallback')) && jsonData.anilist_id)
         return `https://anilist.co/anime/${jsonData.anilist_id}`;
       return false;
     },

--- a/src/pages/animepahe/main.ts
+++ b/src/pages/animepahe/main.ts
@@ -52,11 +52,11 @@ export const animepahe: pageInterface = {
     getMalUrl(provider) {
       const mal = $('meta[name=myanimelist]').attr('content');
       if (mal) return `https://myanimelist.net/anime/${mal}`;
-      if (provider === 'ANILIST') {
+      if (provider === 'ANILIST' || api.settings.get('syncFallback')) {
         const al = $('meta[name=anilist]').attr('content');
         if (al) return `https://anilist.co/anime/${al}`;
       }
-      if (provider === 'KITSU') {
+      if (provider === 'KITSU' || api.settings.get('syncFallback')) {
         const kitsu = $('meta[name=kitsu]').attr('content');
         if (kitsu) return `https://kitsu.app/anime/${kitsu}`;
       }


### PR DESCRIPTION
I added the option `syncFallback` to use other sync modes for entries not available for the current sync mode.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/b4997cd1-7d72-4351-8d22-9dec3bfcccff" />

On this [MangaDex page](https://mangadex.org/title/3b62f955-732c-43b2-84e7-cc1ff57896a7/abandoned-tsuyosugite-buki-ga-kowareru-yuusha-to-buki-shokunin-no-elf) when `syncMode` is `ANILIST` and `syncFallback` is `false`, MALSync falls back to `Local`.

<img width="303" alt="image" src="https://github.com/user-attachments/assets/f72a6acd-9cb5-4104-bf41-e08057b6e99a" />

When `syncFallback` is `true`, MALSync falls back to `MAL` instead.

<img width="278" alt="image" src="https://github.com/user-attachments/assets/ef2273ab-6252-4b09-95dc-8bd3b702e502" />

The entry also shows up in user lists, though it requires scrolling past all the `mode == syncMode` entries (maybe find a way to merge the user lists?). Duplicate entries are removed by comparing `cacheKey`.

<img width="496" alt="image" src="https://github.com/user-attachments/assets/78b87293-def9-47ca-ab56-37605f24d485" />

Search works by concatenating the search from different modes with `mode == syncMode` entries at the top, but duplicates aren't removed since there isn't a simple way to remove them.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/243f1c36-78c9-4770-8122-9fa7cf53c158" />
