### PR TITLE
add manga chapter completion percentage setting

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -894,8 +894,18 @@
         "description": "Manual"
     },
     "settings_Mangasync_readerTracking": {
-        "message": "Sync manga after 90% of the pages",
-        "description": "Option to track the reading progress of a manga and if 90% of the manga is read, set the chapter to read"
+        "message": "Sync manga after reading $mangaCompletionPercentage$% of the pages",
+        "description": "Option to track the reading progress of a manga and if 10-100% of the manga is read, set the chapter to read",
+        "placeholders": {
+            "mangaCompletionPercentage": {
+                "content": "$1",
+                "example": "90"
+            }
+        }
+    },
+    "settings_Mangasync_readerTracking_percentage": {
+        "message": "Update chapter to read at percentage",
+        "description": "Slider to control at what percentage a manga chapter is considered complete"
     },
     "settings_Mangasync": {
         "message": "Manga sync fallback",

--- a/src/_minimal/components/settings/settings-structure-tracking.ts
+++ b/src/_minimal/components/settings/settings-structure-tracking.ts
@@ -135,10 +135,27 @@ export const tracking: ConfObj[] = [
   },
   {
     key: 'readerTracking',
-    title: () => api.storage.lang('settings_Mangasync_readerTracking'),
+    title: () =>
+      api.storage.lang('settings_Mangasync_readerTracking', [
+        api.settings.get('mangaCompletionPercentage'),
+      ]),
     props: {
       component: 'checkbox',
       option: 'readerTracking',
+    },
+    component: SettingsGeneral,
+  },
+  {
+    key: 'mangaCompletionPercentage',
+    title: () => api.storage.lang('settings_Mangasync_readerTracking_percentage'),
+    condition: () => api.settings.get('readerTracking'),
+    props: {
+      component: 'input',
+      option: 'mangaCompletionPercentage',
+      props: {
+        suffix: '%',
+        validation: (value: number) => Boolean(value >= 10 && value < 100),
+      },
     },
     component: SettingsGeneral,
   },

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -24,6 +24,7 @@ export const settingsObj = {
     malResume: true,
     usedPage: true,
     epPredictions: true,
+    mangaCompletionPercentage: 90,
 
     theme: 'auto',
     themeSidebars: true,

--- a/src/utils/mangaProgress/MangaProgress.ts
+++ b/src/utils/mangaProgress/MangaProgress.ts
@@ -80,7 +80,7 @@ export class MangaProgress {
   }
 
   protected getLimit() {
-    const percentage = 90;
+    const percentage = api.settings.get('mangaCompletionPercentage');
     const result = this.getProgress();
     if (result === null) return 0;
     const limit = Math.floor((result.total / 100) * percentage);


### PR DESCRIPTION
solves #2811 

new setting changes the amount of a manga chapter that needs to be read before it is marked as read.

![image](https://github.com/user-attachments/assets/4ef43600-5a94-484c-92e5-02baaccac8c4)
