### PR TITLE
add gojo.wtf page

### DIFF
--- a/src/pages/Gojo/main.ts
+++ b/src/pages/Gojo/main.ts
@@ -1,0 +1,149 @@
+import { pageInterface } from '../pageInterface';
+
+export const Gojo: pageInterface = {
+  name: 'Gojo',
+  domain: 'https://gojo.wtf',
+  languages: ['English'],
+  type: 'anime',
+  isSyncPage(url) {
+    return utils.urlPart(url, 3) === 'watch';
+  },
+  isOverviewPage(url) {
+    return utils.urlPart(url, 3) === 'anime';
+  },
+  sync: {
+    getTitle(url) {
+      return j.$('#root > main > div > div.INFO a[href^="/anime/"] > span').text();
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 4);
+    },
+    getOverviewUrl(url) {
+      return `${Gojo.domain}/anime/${Gojo.sync.getIdentifier(url)}`;
+    },
+    getEpisode(url) {
+      return parseInt(
+        new URL(url).searchParams.get('ep') ??
+          j
+            .$('#root > main > div.WATCH > div.Video span:contains(You are Watching)')
+            .next()
+            .text()
+            .split(' ')[1] ??
+          '1',
+      );
+    },
+    nextEpUrl(url) {
+      const button = j.$(
+        '#root > main > div.WATCH > div.Episode > div > button.order-\\[-999999\\]',
+      );
+      if (button.length) {
+        return Gojo.overview?.list?.elementUrl!(button);
+      }
+      return undefined;
+    },
+    uiSelector(selector) {
+      j.$('#root > main > div > div.INFO div:has(> a[href^="/anime/"])').after(j.html(selector));
+    },
+    getMalUrl(provider) {
+      if (provider === 'ANILIST') {
+        return `https://anilist.co/anime/${Gojo.sync.getIdentifier(window.location.href)}`;
+      }
+      return false;
+    },
+  },
+  overview: {
+    getTitle(url) {
+      return document.title;
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 4);
+    },
+    uiSelector(selector) {
+      j.$('#root > main div:has(> a[href^="/watch/"])').after(j.html(selector));
+    },
+    getMalUrl(provider) {
+      if (provider === 'ANILIST') {
+        return `https://anilist.co/anime/${Gojo.sync.getIdentifier(window.location.href)}`;
+      }
+      return false;
+    },
+    list: {
+      offsetHandler: false,
+      elementsSelector() {
+        return j.$(
+          '#root > main > div.WATCH > div.Episode > div > button:not(.order-\\[-999999\\])',
+        );
+      },
+      elementUrl(selector) {
+        return `${Gojo.domain}/watch/${Gojo.sync.getIdentifier(window.location.href)}?ep=${Gojo.overview?.list?.elementEp(selector)}`;
+      },
+      elementEp(selector) {
+        return Number(selector.find('span:contains(Ep)').text().split(' ')[1]);
+      },
+      paginationNext() {
+        const select = j.$('#root > main > div.WATCH > div.Episode > div > select');
+        if (select.length) {
+          const next = select.find(`> option[value="${select.val()}"]`).next();
+          if (next.length) {
+            next.prop('selected', true);
+            select[0].dispatchEvent(
+              new Event('change', {
+                bubbles: true,
+              }),
+            );
+            return true;
+          }
+        }
+        return false;
+      },
+    },
+  },
+  init(page) {
+    api.storage.addStyle(
+      require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
+    );
+
+    utils.changeDetect(
+      () => {
+        if (Gojo.overview?.list?.elementsSelector().length) {
+          page.handleList();
+        }
+      },
+      () => {
+        return Gojo.overview?.list?.elementsSelector().length;
+      },
+    );
+
+    function waitFn() {
+      if (Gojo.isSyncPage(window.location.href)) {
+        return Gojo.sync?.getTitle(window.location.href);
+      }
+      if (Gojo.isOverviewPage!(window.location.href)) {
+        return j.$('#root > main a[href^="/watch/"]').length;
+      }
+      return false;
+    }
+
+    let waitTimer: NodeJS.Timer | undefined;
+    let watch2getherTimer: number | undefined;
+
+    function check() {
+      clearInterval(waitTimer);
+      waitTimer = undefined;
+      clearInterval(watch2getherTimer);
+      watch2getherTimer = undefined;
+      page.reset();
+      if (Gojo.isSyncPage(window.location.href) || Gojo.isOverviewPage!(window.location.href)) {
+        waitTimer = utils.waitUntilTrue(waitFn, function () {
+          con.info('Check');
+          page.handlePage();
+        });
+      }
+    }
+
+    j.$(document).ready(function () {
+      check();
+    });
+    utils.urlChangeDetect(() => check());
+  },
+};

--- a/src/pages/Gojo/main.ts
+++ b/src/pages/Gojo/main.ts
@@ -122,13 +122,10 @@ export const Gojo: pageInterface = {
     }
 
     let waitTimer: NodeJS.Timer | undefined;
-    let watch2getherTimer: number | undefined;
 
     function check() {
       clearInterval(waitTimer);
       waitTimer = undefined;
-      clearInterval(watch2getherTimer);
-      watch2getherTimer = undefined;
       page.reset();
       if (Gojo.isSyncPage(window.location.href) || Gojo.isOverviewPage!(window.location.href)) {
         waitTimer = utils.waitUntilTrue(waitFn, function () {

--- a/src/pages/Gojo/main.ts
+++ b/src/pages/Gojo/main.ts
@@ -41,9 +41,6 @@ export const Gojo: pageInterface = {
       }
       return undefined;
     },
-    uiSelector(selector) {
-      j.$('#root > main > div > div.INFO div:has(> a[href^="/anime/"])').after(j.html(selector));
-    },
     getMalUrl(provider) {
       if (provider === 'ANILIST') {
         return `https://anilist.co/anime/${Gojo.sync.getIdentifier(window.location.href)}`;

--- a/src/pages/Gojo/meta.json
+++ b/src/pages/Gojo/meta.json
@@ -1,0 +1,8 @@
+{
+  "search": "https://gojo.wtf/search?query={searchtermPlus}",
+  "urls": {
+    "match": [
+      "*://gojo.wtf/*"
+    ]
+  }
+}

--- a/src/pages/Gojo/style.less
+++ b/src/pages/Gojo/style.less
@@ -1,0 +1,44 @@
+@import './../pages';
+
+@textColor: rgba(255 255 255 / 95%);
+
+#malp {
+  color: rgba(255 255 255 / 50%);
+
+  #MalData {
+    justify-content: center !important;
+
+    @media (min-width: 640px) {
+      justify-content: flex-start !important;
+    }
+
+    & > span.malp-group {
+      margin: 0 5px 5px 0;
+      background: var(--lightt);
+      padding: 6px 10px;
+      border-radius: 0.25rem;
+      white-space: pre-wrap !important;
+      font-size: 12px;
+      float: left;
+      display: flex !important;
+      flex-wrap: wrap !important;
+      justify-content: center !important;
+
+      &.malp-group-rating > #AddMalDiv {
+        font-size: 0 !important;
+
+        * {
+          font-size: var(--bs-body-font-size) !important;
+        }
+      }
+
+      & > * {
+        margin: 0;
+      }
+    }
+  }
+}
+
+.mal-sync-active {
+  background-color: @activeEp !important;
+}

--- a/src/pages/Gojo/tests.json
+++ b/src/pages/Gojo/tests.json
@@ -1,0 +1,50 @@
+{
+  "title": "Gojo",
+  "url": "https://gojo.wtf/",
+  "enabled": false,
+  "testCases": [
+    {
+      "url": "https://gojo.wtf/watch/19815",
+      "expected": {
+        "sync": true,
+        "title": "No Game, No Life",
+        "identifier": "19815",
+        "overviewUrl": "https://gojo.wtf/anime/19815",
+        "nextEpUrl": "https://gojo.wtf/watch/19815?ep=2",
+        "episode": 1,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/19815",
+        "epList": {
+          "2": "https://gojo.wtf/watch/19815?ep=2"
+        }
+      }
+    },
+    {
+      "url": "https://gojo.wtf/watch/19815?ep=4",
+      "expected": {
+        "sync": true,
+        "title": "No Game, No Life",
+        "identifier": "19815",
+        "overviewUrl": "https://gojo.wtf/anime/19815",
+        "nextEpUrl": "https://gojo.wtf/watch/19815?ep=5",
+        "episode": 4,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/19815",
+        "epList": {
+          "5": "https://gojo.wtf/watch/19815?ep=5"
+        }
+      }
+    },
+    {
+      "url": "https://gojo.wtf/anime/19815",
+      "expected": {
+        "sync": false,
+        "title": "No Game, No Life",
+        "identifier": "19815",
+        "episode": 1,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/57616"
+      }
+    }
+  ]
+}

--- a/src/pages/Gojo/tests.json
+++ b/src/pages/Gojo/tests.json
@@ -43,7 +43,7 @@
         "identifier": "19815",
         "episode": 1,
         "uiSelector": true,
-        "malUrl": "https://myanimelist.net/anime/57616"
+        "malUrl": "https://myanimelist.net/anime/19815"
       }
     }
   ]

--- a/src/pages/Gojo/tests.json
+++ b/src/pages/Gojo/tests.json
@@ -12,7 +12,7 @@
         "overviewUrl": "https://gojo.wtf/anime/19815",
         "nextEpUrl": "https://gojo.wtf/watch/19815?ep=2",
         "episode": 1,
-        "uiSelector": true,
+        "uiSelector": false,
         "malUrl": "https://myanimelist.net/anime/19815",
         "epList": {
           "2": "https://gojo.wtf/watch/19815?ep=2"
@@ -28,7 +28,7 @@
         "overviewUrl": "https://gojo.wtf/anime/19815",
         "nextEpUrl": "https://gojo.wtf/watch/19815?ep=5",
         "episode": 4,
-        "uiSelector": true,
+        "uiSelector": false,
         "malUrl": "https://myanimelist.net/anime/19815",
         "epList": {
           "5": "https://gojo.wtf/watch/19815?ep=5"

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -140,6 +140,7 @@ import { Rawkuma } from './Rawkuma/main';
 import { Aninexus } from './Aninexus/main';
 import { AnimeKAI } from './AnimeKAI/main';
 import { Hikari } from './Hikari/main';
+import { Gojo } from './Gojo/main';
 
 export const pages = {
   Crunchyroll,
@@ -284,4 +285,5 @@ export const pages = {
   Aninexus,
   AnimeKAI,
   Hikari,
+  Gojo,
 };


### PR DESCRIPTION
gojo.live redirects to gojo.wtf, so gojo.live is not listed as one of the domains

This site uses anilist IDs, so maintaining the database for gojo (if ever implemented) would not require manually adding and checking the entries.

closes #2436