### PR TITLE
HiAnime fix ui selector

### DIFF
--- a/src/pages/Zoro/main.ts
+++ b/src/pages/Zoro/main.ts
@@ -42,6 +42,9 @@ export const Zoro: pageInterface = {
     nextEpUrl(url) {
       return jsonData.next_episode_url;
     },
+    uiSelector(selector) {
+      j.$('div.film-description').before(j.html(selector));
+    },
     getMalUrl(provider) {
       if (jsonData.mal_id) return `https://myanimelist.net/anime/${jsonData.mal_id}`;
       if (provider === 'ANILIST' && jsonData.anilist_id)
@@ -57,7 +60,8 @@ export const Zoro: pageInterface = {
       return jsonData.anime_id;
     },
     uiSelector(selector) {
-      j.$(jsonData.selector_position!).append(j.html(selector));
+      j.$(jsonData.selector_position!).detach();
+      j.$('div.film-description').before(j.html(selector));
     },
     getMalUrl(provider) {
       return Zoro.sync.getMalUrl!(provider);


### PR DESCRIPTION
Changes the location of MAL-Sync's UI on HiAnime to be consistent with other sites, such as MangaDex, AnimeKAI, etc.

Also adds MAL-Sync's UI on the sync page.