### PR TITLE
Overview/Search bar fixes

### DIFF
--- a/src/_minimal/components/form/form-switch.vue
+++ b/src/_minimal/components/form/form-switch.vue
@@ -6,8 +6,9 @@
         v-model="picked"
         class="input"
         type="radio"
-        name="radio-slide"
+        :name="`radio-slide-${id}`"
         :value="option.value"
+        :checked="modelValue === option.value"
       />
       <label
         class="label"
@@ -37,7 +38,7 @@ const props = defineProps({
   },
   modelValue: {
     type: String,
-    require: true,
+    required: true,
     default: '',
   },
 });

--- a/src/_minimal/views/overview.vue
+++ b/src/_minimal/views/overview.vue
@@ -275,7 +275,8 @@ const cleanDescription = computed(() => {
   if (!metaRequest.data) return '';
   const { description } = metaRequest.data;
   if (!description) return '';
-  return description.replace(/(< *\/? *br *\/? *>(\r|\n| )*){2,}/gim, '<br /><br />');
+  const cleanedBr = description.replace(/(< *\/? *br *\/? *>(\r|\n| )*){2,}/gim, '<br /><br />');
+  return cleanedBr.replace(/<a\b/gi, '<a target="_blank" rel="noopener noreferrer"');
 });
 
 const totalLoading = computed(() => {
@@ -352,6 +353,9 @@ const totalLoading = computed(() => {
   }
 
   .description-html {
+    :deep(a) {
+      color: var(--cl-secondary-text);
+    }
     &.preLine {
       white-space: pre-line;
     }


### PR DESCRIPTION
There were several issues. Sending in 1 PR since they are quite small.
Issues:
1. Despite overview description section's div having `description-html` class, links tags looks the same as normal text. I think it will be better to somehow highlight them.
2. Said links MAY also open in pop up window itself, not in new browser tab (if they don't have target attr).
3. Using search bar from bookmarks view AND erasing input or going back to bookmarks makes both anime/manga radio switches unchecked

Obviously links only works if they are provided in description string as part of meta data. 

<details><summary>Search bar before:</summary>
<p>

![search1](https://github.com/user-attachments/assets/6c347abc-e515-4db8-a34a-c567349320f8)

</p>
</details> 
<details><summary>Search bar after:</summary>
<p>

![search2](https://github.com/user-attachments/assets/7da0ff3e-d35c-43a0-8c76-7faa902fd322)

</p>
</details> 
<details><summary>Overview description before:</summary>
<p>

![links1](https://github.com/user-attachments/assets/64455271-3bad-4bda-b277-018b3d6efc1f)

</p>
</details> 
<details><summary>Overview description after:</summary>
<p>

Do not mind changed banner. That's another PR
![links2](https://github.com/user-attachments/assets/00fffff1-a7f7-44f5-b4bf-897c35697e32)

</p>
</details> 
<h6>*pardon my overview in different lang</h6>