### PR TITLE
Tests - fixed daylight saving time zone

### DIFF
--- a/test/src/utils/time.test.ts
+++ b/test/src/utils/time.test.ts
@@ -8,13 +8,13 @@ describe('Time', function() {
     Date.now = () => dateNow;
   });
   describe('dateFromTimezoneToTimezone', function() {
-    it('+1', function() {
-      const res = timeM.dateFromTimezoneToTimezone(new Date(Date.UTC(2024, 11, 1, 14, 10)), 'UTC', 'Europe/Berlin');
-      expect(res).to.deep.equal(new Date(Date.UTC(2024, 11, 1, 15, 10)));
+    it('+3', function() {
+      const res = timeM.dateFromTimezoneToTimezone(new Date(Date.UTC(2024, 11, 1, 14, 10)), 'UTC', 'Europe/Moscow');
+      expect(res).to.deep.equal(new Date(Date.UTC(2024, 11, 1, 17, 10)));
     })
-    it('-1', function() {
-      const res = timeM.dateFromTimezoneToTimezone(new Date(Date.UTC(2024, 11, 1, 14, 10)), 'Europe/Berlin', 'UTC');
-      expect(res).to.deep.equal(new Date(Date.UTC(2024, 11, 1, 13, 10)));
+    it('-3', function() {
+      const res = timeM.dateFromTimezoneToTimezone(new Date(Date.UTC(2024, 11, 1, 14, 10)), 'Europe/Moscow', 'UTC');
+      expect(res).to.deep.equal(new Date(Date.UTC(2024, 11, 1, 11, 10)));
     })
     it('0', function() {
       const res = timeM.dateFromTimezoneToTimezone(new Date(Date.UTC(2024, 11, 1, 14, 10)), 'UTC', 'UTC');


### PR DESCRIPTION
Since I wasn't expecting this 3 months ago, here's a fix for time tests.
Apparently Berlin has daylight saving time. 

> Daylight saving time - is observed from the last Sunday in March (02:00 CET) to the last Sunday in October (03:00 CEST)

And also to my surprise you can't use "+01" or "+01:00" UTC time offsets while using node < 22
https://github.com/nodejs/node/issues/53419#issuecomment-2162048443

So I think easiest is just to use time zone without DST
Until this fixed, every tests check will be failed