### PR TITLE
Update Toonily.com to new url path

### DIFF
--- a/src/pages/Toonily/main.ts
+++ b/src/pages/Toonily/main.ts
@@ -10,7 +10,7 @@ export const Toonily: pageInterface = {
   },
   sync: {
     getTitle(url) {
-      return j.$('.breadcrumb li > a[href*="/webtoon/"]').text().trim();
+      return j.$('.breadcrumb li > a[href*="/serie/"]').text().trim();
     },
     getIdentifier(url) {
       return url.split('/')[4];
@@ -18,7 +18,7 @@ export const Toonily: pageInterface = {
     getOverviewUrl(url) {
       return (
         utils.absoluteLink(
-          j.$('.breadcrumb li > a[href*="/webtoon/"]').attr('href'),
+          j.$('.breadcrumb li > a[href*="/serie/"]').attr('href'),
           Toonily.domain,
         ) || ''
       );
@@ -71,7 +71,7 @@ export const Toonily: pageInterface = {
     );
     j.$(document).ready(function () {
       if (
-        utils.urlPart(page.url, 3) === 'webtoon' &&
+        utils.urlPart(page.url, 3) === 'serie' &&
         utils.urlPart(page.url, 4) !== undefined &&
         utils.urlPart(page.url, 4).length > 0
       ) {

--- a/src/pages/Toonily/meta.json
+++ b/src/pages/Toonily/meta.json
@@ -1,6 +1,6 @@
 {
   "search": "https://toonily.com/?s={searchtermPlus}&post_type=wp-manga",
   "urls": {
-    "match": ["*://toonily.com/webtoon/*"]
+    "match": ["*://toonily.com/serie/*"]
   }
 }

--- a/src/pages/Toonily/tests.json
+++ b/src/pages/Toonily/tests.json
@@ -3,27 +3,27 @@
   "url": "https://toonily.com/",
   "testCases": [
     {
-      "url": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-125/",
+      "url": "https://toonily.com/serie/skeleton-protect-dungeon/chapter-125/",
       "expected": {
         "sync": true,
         "title": "Skeleton Soldier Couldn’t Protect the Dungeon",
         "identifier": "skeleton-protect-dungeon",
-        "overviewUrl": "https://toonily.com/webtoon/skeleton-protect-dungeon/",
-        "nextEpUrl": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-126/",
+        "overviewUrl": "https://toonily.com/serie/skeleton-protect-dungeon/",
+        "nextEpUrl": "https://toonily.com/serie/skeleton-protect-dungeon/chapter-126/",
         "episode": 125,
         "uiSelector": false
       }
     },
     {
-      "url": "https://toonily.com/webtoon/skeleton-protect-dungeon/",
+      "url": "https://toonily.com/serie/skeleton-protect-dungeon/",
       "expected": {
         "sync": false,
         "title": "Skeleton Soldier Couldn’t Protect the Dungeon",
         "identifier": "skeleton-protect-dungeon",
         "uiSelector": true,
         "epList": {
-          "120": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-120/",
-          "125": "https://toonily.com/webtoon/skeleton-protect-dungeon/chapter-125/"
+          "120": "https://toonily.com/serie/skeleton-protect-dungeon/chapter-120/",
+          "125": "https://toonily.com/serie/skeleton-protect-dungeon/chapter-125/"
         }
       }
     }


### PR DESCRIPTION
I noticed that [Toonily.com](https://toonily.com/) was broken and the issue appears to stem from the URL path for the [webtoons](https://toonily.com/serie/overgeared/) changing from `webtoon` to `serie` and updating this appears to fix support for the site as both the integration on the pages and search functionality appear to be working again when loading the extension from disk. 

Please let me know if there are any issues and I will try to address them.

Thanks!