### PR TITLE
Add Animeav1 support [ES]

### DIFF
--- a/src/pages-chibi/implementations/animeav1/main.ts
+++ b/src/pages-chibi/implementations/animeav1/main.ts
@@ -31,9 +31,6 @@ export const animeav1: PageInterface = {
       const nextEp = $c.querySelector('.ic-chevron-right').parent().getAttribute('href');
       return $c.if(nextEp.boolean().run(), nextEp.urlAbsolute().run(), $c.string('').run()).run();
     },
-    uiInjection($c) {
-      return $c.querySelector('div.container > div.items-start > div.flex-wrap').uiAfter().run();
-    },
   },
   overview: {
     isOverviewPage($c) {
@@ -42,7 +39,7 @@ export const animeav1: PageInterface = {
         .run();
     },
     getTitle($c) {
-      return $c.querySelector('div.text-main a').text().trim().run();
+      return $c.querySelector('h1').text().trim().run();
     },
     getIdentifier($c) {
       return $c.url().this('sync.getIdentifier').run();
@@ -56,10 +53,10 @@ export const animeav1: PageInterface = {
       return $c.querySelectorAll('article.group\\/item').run();
     },
     elementUrl($c) {
-      return $c.find('a').first().getAttribute('href').urlAbsolute().run();
+      return $c.find('a').getAttribute('href').urlAbsolute().run();
     },
     elementEp($c) {
-      return $c.querySelector('div > div > div > span').text().trim().number().run();
+      return $c.this('list.elementUrl').this('sync.getEpisode').run();
     },
   },
   lifecycle: {
@@ -68,7 +65,7 @@ export const animeav1: PageInterface = {
       return $c.addStyle(require('./style.less?raw').toString()).run();
     },
     ready($c) {
-      return $c.domReady().trigger().run();
+      return $c.detectURLChanges($c.trigger().run()).domReady().trigger().run();
     },
   },
 };

--- a/src/pages-chibi/implementations/animeav1/main.ts
+++ b/src/pages-chibi/implementations/animeav1/main.ts
@@ -1,0 +1,74 @@
+import { PageInterface } from '../../pageInterface';
+
+export const animeav1: PageInterface = {
+  name: 'Animeav1',
+  type: 'anime',
+  domain: 'https://animeav1.com',
+  languages: ['Spanish'],
+  urls: {
+    match: ['*://animeav1.com/*'],
+  },
+  search: 'https://animeav1.com/catalogo?search={searchtermPlus}',
+  sync: {
+    isSyncPage($c) {
+      return $c
+        .and($c.url().urlPart(3).equals('media').run(), $c.url().urlPart(5).boolean().run())
+        .run();
+    },
+    getTitle($c) {
+      return $c.querySelector('div.text-main a').text().trim().run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlPart(4).run();
+    },
+    getOverviewUrl($c) {
+      return $c.querySelector('div.text-main a').getAttribute('href').urlAbsolute().run();
+    },
+    getEpisode($c) {
+      return $c.url().urlPart(5).number().run();
+    },
+    nextEpUrl($c) {
+      const nextEp = $c.querySelector('.ic-chevron-right').parent().getAttribute('href');
+      return $c.if(nextEp.boolean().run(), nextEp.urlAbsolute().run(), $c.string('').run()).run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('div.container > div.items-start > div.flex-wrap').uiAfter().run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c
+        .and($c.url().urlPart(3).equals('media').run(), $c.url().urlPart(5).boolean().not().run())
+        .run();
+    },
+    getTitle($c) {
+      return $c.querySelector('div.text-main a').text().trim().run();
+    },
+    getIdentifier($c) {
+      return $c.url().this('sync.getIdentifier').run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('article div.entry').uiAfter().run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll('article.group\\/item').run();
+    },
+    elementUrl($c) {
+      return $c.find('a').first().getAttribute('href').urlAbsolute().run();
+    },
+    elementEp($c) {
+      return $c.querySelector('div > div > div > span').text().trim().number().run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c.domReady().trigger().run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/animeav1/style.less
+++ b/src/pages-chibi/implementations/animeav1/style.less
@@ -1,0 +1,42 @@
+@import './../pages';
+
+@textColor: rgb(var(--color-text) / var(--tw-text-opacity, 1));
+@inputBackground: rgb(var(--color-body) / var(--tw-bg-opacity, 1));
+
+#malp * {
+  min-width: auto;
+
+  input {
+    min-height: 1rem;
+  }
+
+  select {
+    padding-left: 5px !important;
+  }
+
+  div.flex-wrap #malStatus,
+  div.flex-wrap #malUserRating {
+    background-color: rgb(var(--color-mute) / var(--tw-bg-opacity, 1));
+  }
+
+  #malEpisodes {
+    display: inline-block;
+    border: 0;
+    padding: 0;
+    margin-bottom: 4px;
+  }
+
+  .malp-group-score,
+  .malp-group-status {
+    display: flex;
+    flex-flow: row;
+  }
+
+  .malp-group-label {
+    text-wrap: nowrap;
+  }
+
+  .malp-group-select {
+    min-height: 1rem;
+  }
+}

--- a/src/pages-chibi/implementations/animeav1/style.less
+++ b/src/pages-chibi/implementations/animeav1/style.less
@@ -1,5 +1,8 @@
 @import './../pages';
 
+@highlightStyle: 0;
+@activeEp: rgb(var(--color-main) / var(--tw-text-opacity, 1));
+
 @textColor: rgb(var(--color-text) / var(--tw-text-opacity, 1));
 @inputBackground: rgb(var(--color-body) / var(--tw-bg-opacity, 1));
 
@@ -39,4 +42,8 @@
   .malp-group-select {
     min-height: 1rem;
   }
+}
+
+.mal-sync-active {
+  border: 2px solid @activeEp;
 }

--- a/src/pages-chibi/implementations/animeav1/tests.json
+++ b/src/pages-chibi/implementations/animeav1/tests.json
@@ -1,0 +1,27 @@
+{
+  "title": "Animeav1",
+  "url": "https://animeav1.com",
+  "testCases": [
+    {
+      "url": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru",
+      "expected": {
+        "sync": false,
+        "title": "Ore wa Subete wo \"Parry\" suru: Gyaku Kanchigai no Sekai Saikyou wa Boukensha ni Naritai",
+        "identifier": "ore-wa-subete-wo-parry-suru",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru/8",
+      "expected": {
+        "sync": true,
+        "title": "Ore wa Subete wo \"Parry\" suru: Gyaku Kanchigai no Sekai Saikyou wa Boukensha ni Naritai",
+        "identifier": "ore-wa-subete-wo-parry-suru",
+        "episode": 8,
+        "overviewUrl": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru",
+        "nextEpUrl": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru/9",
+        "uiSelector": true
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/implementations/animeav1/tests.json
+++ b/src/pages-chibi/implementations/animeav1/tests.json
@@ -20,7 +20,7 @@
         "episode": 8,
         "overviewUrl": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru",
         "nextEpUrl": "https://animeav1.com/media/ore-wa-subete-wo-parry-suru/9",
-        "uiSelector": true
+        "uiSelector": false
       }
     }
   ]

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -1,5 +1,6 @@
 import { PageInterface } from './pageInterface';
 
+import { animeav1 } from './implementations/animeav1/main';
 import { mangaNato } from './implementations/mangaNato/main';
 import { gojo } from './implementations/gojo/main';
 import { animeLib } from './implementations/animeLib/main';
@@ -13,6 +14,7 @@ import { bato } from './implementations/bato/main';
 import { Crunchyroll } from './implementations/Crunchyroll/main';
 
 export const pages: { [key: string]: PageInterface } = {
+  animeav1,
   mangaNato,
   gojo,
   animeLib,

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -800,4 +800,8 @@ module.exports = {
   boosterx: {
     match: ['*://boosterx.stream/*'],
   },
+  // animeav1
+  animeav1: {
+    match: ['*://player.zilla-networks.com/*'],
+  },
 };


### PR DESCRIPTION
This PR implement support for the Animeav1 site, as requested in the issue https://github.com/MALSync/MALSync/issues/3009.

Enables full site support with UI selector for both light and dark themes, and tests for both overview and sync pages.

Note: The last PR #3036 closed automatically due to a forced push in my fork, sorry!