### PR TITLE
Fixes same name item in quicklinks issue

### DIFF
--- a/src/utils/quicklinksBuilder.ts
+++ b/src/utils/quicklinksBuilder.ts
@@ -184,12 +184,16 @@ export function getQuicklinks(): QuicklinkObject[] {
         typeof el.search === 'object'
           ? el.search
           : {
-            anime: el.type === 'anime' ? el.search || null : null,
-            manga: el.type === 'manga' ? el.search || null : null,
-          },
+              anime: el.type === 'anime' ? el.search || null : null,
+              manga: el.type === 'manga' ? el.search || null : null,
+            },
     };
   });
 
+  // **Solves a duplication issue when searching for quicklinks, caused by having 2 instances of the same name**
+  // If a chibi quicklink has the same name as a page quicklink, it will overwrite it
+  // This is done to ensure that chibi quicklinks are always preferred over pages quicklinks
+  // This is because chibi quicklinks are more up-to-date and maintained
   const combined = new Map<string, QuicklinkObject>();
   quicklinkPages.forEach(p => combined.set(p.name, p));
   quicklinkChibi.forEach(c => combined.set(c.name, c));

--- a/src/utils/quicklinksBuilder.ts
+++ b/src/utils/quicklinksBuilder.ts
@@ -184,13 +184,17 @@ export function getQuicklinks(): QuicklinkObject[] {
         typeof el.search === 'object'
           ? el.search
           : {
-              anime: el.type === 'anime' ? el.search || null : null,
-              manga: el.type === 'manga' ? el.search || null : null,
-            },
+            anime: el.type === 'anime' ? el.search || null : null,
+            manga: el.type === 'manga' ? el.search || null : null,
+          },
     };
   });
 
-  tempQuicklinks = [...quicklinkPages, ...quicklinkChibi];
+  const combined = new Map<string, QuicklinkObject>();
+  quicklinkPages.forEach(p => combined.set(p.name, p));
+  quicklinkChibi.forEach(c => combined.set(c.name, c));
+
+  tempQuicklinks = Array.from(combined.values());
   return tempQuicklinks;
 }
 


### PR DESCRIPTION
Resolve the duplication of quicklinks with the same name by prioritizing chibi quicklinks over page quicklinks.