### PR TITLE
Feat/diziwatch animecix support

### DIFF
--- a/src/pages-chibi/implementations/Animecix/main.ts
+++ b/src/pages-chibi/implementations/Animecix/main.ts
@@ -1,0 +1,111 @@
+import { PageInterface } from '../../pageInterface';
+
+function extractSlug($c) {
+  return $c.url().regex('titles/\\d+/([^/]+)', 1).run();
+}
+
+function extractSeason($c) {
+  return $c.url().regex('season/(\\d+)', 1).run();
+}
+
+function extractEpisodeNumber($c) {
+  return $c.url().regex('episode/(\\d+)', 1).number().run();
+}
+
+function getOverviewAnchor($c) {
+  return $c.querySelector('h1.t-title a[href*="/titles/"]:not([href*="/season/"])').ifNotReturn();
+}
+
+export const Animecix: PageInterface = {
+  name: 'Animecix',
+  type: 'anime',
+  domain: 'https://animecix.tv',
+  languages: ['Turkish'],
+  urls: {
+    match: ['*://*.animecix.tv/*', '*://*.animecix.com/*', '*://*.animecix.net/*'],
+  },
+  sync: {
+    isSyncPage($c) {
+      // Improved regex pattern to ensure we're matching the correct URL structure
+      return $c.url().regex('titles/\\d+/[^/]+/season/\\d+/episode/\\d+', 0).boolean().run();
+    },
+    getTitle($c) {
+      return getOverviewAnchor($c).text().trim().run();
+    },
+    getIdentifier($c) {
+      const slug = extractSlug($c);
+      const season = extractSeason($c);
+      // Simplified approach to handle ChibiJson values
+      return $c.string(slug).run();
+    },
+    getOverviewUrl($c) {
+      return getOverviewAnchor($c).getAttribute('href').urlAbsolute().run();
+    },
+    getEpisode($c) {
+      return extractEpisodeNumber($c);
+    },
+    nextEpUrl($c) {
+      // Simplified implementation using only ChibiScript functions
+      return $c.string('').run();
+    },
+    uiInjection($c) {
+      // Enhanced selector to handle different page structures
+      return $c
+        .querySelector('.episode-details, .rating-meta, .episode-title, .video-meta, .episode-info')
+        .uiAfter()
+        .run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      // Improved detection: overview page is when we have /titles/ID/SLUG but NOT /season/SEASON/episode/EPISODE
+      return $c
+        .and(
+          $c.url().regex('titles/\\d+/[^/]+$', 0).boolean().run(),
+          $c.url().regex('season/\\d+/episode/\\d+', 0).boolean().not().run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      // Use the same approach as sync.getTitle instead of referencing Animecix.sync.getTitle
+      return getOverviewAnchor($c).text().trim().run();
+    },
+    getIdentifier($c) {
+      return extractSlug($c);
+    },
+    getImage($c) {
+      return $c.string('').run(); // Return empty string instead of null
+    },
+    uiInjection($c) {
+      // Enhanced selector to handle different page structures
+      return $c
+        .querySelector('.rating-meta, .title-meta, h1.t-title, .series-meta, .anime-info')
+        .uiAfter()
+        .run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c
+        .querySelectorAll('app-season-episodes a[href*="/season/"][href*="/episode/"]')
+        .run();
+    },
+    elementUrl($c) {
+      return $c.getAttribute('href').urlAbsolute().run();
+    },
+    elementEp($c) {
+      // Use the same approach as other ChibiScript implementations
+      return $c.this('list.elementUrl').this('sync.getEpisode').run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      // Use domReady with detectURLChanges for better page load handling
+      return $c.domReady().trigger().detectURLChanges($c.trigger().run()).run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/Animecix/style.less
+++ b/src/pages-chibi/implementations/Animecix/style.less
@@ -1,0 +1,29 @@
+@import './../pages';
+
+#malsync-container {
+  margin: 16px 0;
+  padding: 12px;
+  background: rgb(0 0 0 / 8%);
+  border-radius: 6px;
+}
+
+.malsync-button {
+  background: #1e88e5;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background-color 0.2s;
+}
+
+.malsync-button:hover {
+  background: #1669b4;
+}
+
+[data-theme='dark'] #malsync-container,
+.dark #malsync-container {
+  background: rgb(255 255 255 / 8%);
+}

--- a/src/pages-chibi/implementations/Animecix/tests.json
+++ b/src/pages-chibi/implementations/Animecix/tests.json
@@ -1,0 +1,31 @@
+{
+  "title": "Animecix",
+  "url": "https://animecix.tv",
+  "testCases": [
+    {
+      "url": "https://animecix.tv/titles/235/fullmetal-alchemist-brotherhood",
+      "expected": {
+        "sync": false,
+        "title": "Fullmetal Alchemist: Brotherhood",
+        "identifier": "fullmetal-alchemist-brotherhood",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://animecix.tv/titles/235/fullmetal-alchemist-brotherhood/season/1/episode/1"
+        }
+      }
+    },
+    {
+      "url": "https://animecix.tv/titles/235/fullmetal-alchemist-brotherhood/season/1/episode/1",
+      "expected": {
+        "sync": true,
+        "title": "Fullmetal Alchemist: Brotherhood",
+        "identifier": "fullmetal-alchemist-brotherhood?season=1",
+        "overviewUrl": "https://animecix.tv/titles/235/fullmetal-alchemist-brotherhood",
+        "episode": 1,
+        "episodeTitle": "Ilk gun",
+        "uiSelector": false
+      }
+    }
+  ]
+}
+

--- a/src/pages-chibi/implementations/Diziwatch/diziwatch-iframe-fix.user.js
+++ b/src/pages-chibi/implementations/Diziwatch/diziwatch-iframe-fix.user.js
@@ -1,0 +1,235 @@
+// ==UserScript==
+// @name         Diziwatch Iframe Player Fix for MALSync
+// @namespace    https://malsync.moe/
+// @version      1.1
+// @description  Fix iframe player detection for Diziwatch in MALSync
+// @match        *://*.diziwatch.tv/*
+// @grant        none
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  // iframe selector for pichive player
+  const IFRAME_SELECTOR = 'iframe[src*="pichive.online"]';
+  const PLAYER_CONTAINER_SELECTOR = '#player-video';
+  const VIDEO_BRIDGE_FLAG = '__malsync_diziwatch_bridge';
+
+  // State management
+  let bridgeState = {
+    lastMsgType: null,
+    lastSent: null,
+    lastSampleCurrent: null,
+    lastSampleDuration: null,
+    lastSampleTs: null,
+    playerDetected: false,
+    iframeSrc: null,
+    messageListenerAdded: false,
+    currentTime: 0,
+    duration: 0,
+    paused: true,
+    isIframeReady: false
+  };
+
+  // Utility functions
+  function parseFiniteNumber(value) {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : undefined;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return undefined;
+      const parsed = Number.parseFloat(trimmed);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    }
+    return undefined;
+  }
+
+  function forwardTime(current, duration, paused) {
+    if (!Number.isFinite(current) || !Number.isFinite(duration) || duration <= 0) return;
+
+    const last = bridgeState.lastSent;
+    if (
+      last &&
+      Math.abs(last.current - current) < 0.05 &&
+      Math.abs(last.duration - duration) < 0.05 &&
+      last.paused === paused
+    ) {
+      return;
+    }
+
+    bridgeState.lastSent = { current, duration, paused };
+    bridgeState.lastSampleCurrent = current;
+    bridgeState.lastSampleDuration = duration;
+    bridgeState.lastSampleTs = Date.now();
+    
+    // Send message to parent window for MALSync integration
+    window.parent.postMessage({
+      type: 'MALSyncPlayerTime',
+      current: current,
+      duration: duration,
+      paused: paused
+    }, '*');
+  }
+
+  // Player message listener
+  function addPlayerMessageListener() {
+    if (bridgeState.messageListenerAdded) return;
+    bridgeState.messageListenerAdded = true;
+
+    const messageHandler = function(event) {
+      try {
+        const data = event.data;
+        if (!data || typeof data !== 'object') return;
+
+        // Handle DiziWatch specific player messages
+        if (data.msgVer === '2' || data.msgVer === 2) {
+          const time = parseFiniteNumber(data?.timeInfo?.time);
+          const duration = parseFiniteNumber(data?.timeInfo?.duration);
+
+          if (time !== undefined && duration !== undefined && duration > 0) {
+            const paused = data.msgType === 'paused' || data.msgType === 'error';
+            forwardTime(time, duration, paused);
+
+            // Update player state
+            bridgeState.currentTime = time;
+            bridgeState.duration = duration;
+            bridgeState.paused = paused;
+            bridgeState.isIframeReady = true;
+
+            // Update last message type
+            if (typeof data.msgType === 'string') {
+              bridgeState.lastMsgType = data.msgType;
+            }
+          }
+        }
+
+        // Handle generic player messages
+        if (data.currentTime !== undefined && data.duration !== undefined) {
+          const current = parseFiniteNumber(data.currentTime);
+          const duration = parseFiniteNumber(data.duration);
+          if (current !== undefined && duration !== undefined && duration > 0) {
+            const paused = data.paused === true;
+            forwardTime(current, duration, paused);
+
+            // Update player state
+            bridgeState.currentTime = current;
+            bridgeState.duration = duration;
+            bridgeState.paused = paused;
+            bridgeState.isIframeReady = true;
+          }
+        }
+
+        // Handle alternative time formats
+        if (data.time !== undefined && data.totalTime !== undefined) {
+          const current = parseFiniteNumber(data.time);
+          const duration = parseFiniteNumber(data.totalTime);
+          if (current !== undefined && duration !== undefined && duration > 0) {
+            const paused = data.paused === true;
+            forwardTime(current, duration, paused);
+
+            // Update player state
+            bridgeState.currentTime = current;
+            bridgeState.duration = duration;
+            bridgeState.paused = paused;
+            bridgeState.isIframeReady = true;
+          }
+        }
+      } catch (e) {
+        console.debug('[MALSync][Diziwatch] Error processing player message', e);
+      }
+    };
+
+    window.addEventListener('message', messageHandler);
+    console.log('[MALSync][Diziwatch] Added player message listener');
+  }
+
+  // Enhanced player detection for iframe-based players
+  function setupPichiveBridge() {
+    if (typeof window === 'undefined') return;
+    const globalScope = window;
+    if (globalScope[VIDEO_BRIDGE_FLAG]) return;
+    globalScope[VIDEO_BRIDGE_FLAG] = true;
+
+    // Player detection and enhanced polling
+    const playerCheckInterval = setInterval(() => {
+      const playerContainer = document.querySelector(PLAYER_CONTAINER_SELECTOR);
+      if (playerContainer && playerContainer.querySelector(IFRAME_SELECTOR)) {
+        const iframe = playerContainer.querySelector(IFRAME_SELECTOR);
+        const iframeSrc = iframe?.src;
+
+        if (!bridgeState.playerDetected) {
+          bridgeState.playerDetected = true;
+          bridgeState.iframeSrc = iframeSrc;
+          bridgeState.isIframeReady = false;
+          console.log('[MALSync][Diziwatch] Player detected with src:', iframeSrc);
+
+          // Add message listener when player is detected
+          if (!bridgeState.messageListenerAdded) {
+            addPlayerMessageListener();
+            bridgeState.messageListenerAdded = true;
+          }
+        } else if (bridgeState.iframeSrc !== iframeSrc) {
+          // If iframe src changed, update it and re-add listener
+          bridgeState.iframeSrc = iframeSrc;
+          bridgeState.isIframeReady = false;
+          console.log('[MALSync][Diziwatch] Player iframe src changed to:', iframeSrc);
+
+          if (!bridgeState.messageListenerAdded) {
+            addPlayerMessageListener();
+            bridgeState.messageListenerAdded = true;
+          }
+        }
+      } else if (bridgeState.playerDetected) {
+        // Player removed, clear state
+        bridgeState.playerDetected = false;
+        bridgeState.iframeSrc = undefined;
+        bridgeState.isIframeReady = false;
+        bridgeState.lastMsgType = undefined;
+        bridgeState.lastSent = undefined;
+        console.log('[MALSync][Diziwatch] Player removed');
+      }
+    }, 3000);
+
+    // Also listen for player messages at the global level
+    window.addEventListener('message', function(event) {
+      const data = event.data;
+      if (!data || typeof data !== 'object') return;
+
+      // Handle DiziWatch specific messages
+      const versionCheck = data.msgVer === '2' || data.msgVer === 2;
+      if (versionCheck) {
+        if (typeof data.msgType === 'string') {
+          bridgeState.lastMsgType = data.msgType;
+        }
+
+        const time = parseFiniteNumber(data?.timeInfo?.time);
+        const duration = parseFiniteNumber(data?.timeInfo?.duration);
+
+        if (time !== undefined && duration !== undefined && duration > 0) {
+          const paused = data.msgType === 'paused' || data.msgType === 'error';
+          forwardTime(time, duration, paused);
+
+          // Update player state
+          bridgeState.currentTime = time;
+          bridgeState.duration = duration;
+          bridgeState.paused = paused;
+          bridgeState.isIframeReady = true;
+
+          if (data.msgType === 'watched') {
+            forwardTime(duration, duration, true);
+          }
+        }
+      }
+    });
+  }
+
+  // Initialize the bridge when the page is loaded
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupPichiveBridge);
+  } else {
+    setupPichiveBridge();
+  }
+
+  console.log('[MALSync][Diziwatch] Iframe player fix loaded');
+})();

--- a/src/pages-chibi/implementations/Diziwatch/diziwatch-test.user.js
+++ b/src/pages-chibi/implementations/Diziwatch/diziwatch-test.user.js
@@ -1,0 +1,227 @@
+// ==UserScript==
+// @name         Diziwatch MALSync Inspector
+// @namespace    https://malsync.moe/
+// @version      0.6
+// @description  Collect selectors for MALSync integration on diziwatch.tv
+// @match        *://*.diziwatch.tv/*
+// @grant        none
+// ==/UserScript==
+
+(function () {
+  'use strict';
+
+  const helpers = {
+    q: (sel) => document.querySelector(sel),
+    qAll: (sel) => Array.from(document.querySelectorAll(sel)),
+    safeText: (el) => el?.textContent?.trim() || null,
+    absUrl: (href) => {
+      try {
+        return new URL(href, location.href).toString();
+      } catch {
+        return href || null;
+      }
+    },
+    uniq: (arr) => Array.from(new Set(arr.filter(Boolean))),
+  };
+
+  function detectPageType() {
+    const url = location.href;
+    if (/bolum|episode/i.test(url)) return 'episode';
+    if (/sezon|season/i.test(url)) return 'season';
+    if (/dizi|series|show/i.test(url)) return 'series';
+    return 'unknown';
+  }
+
+  function collectBasics(info) {
+    info.url = location.href;
+    info.title = document.title;
+    info.pathname = location.pathname;
+    info.pageType = detectPageType();
+  }
+
+  function collectOverview(info) {
+    if (!/dizi|series|show/i.test(location.href)) return;
+    const data = {};
+    const titleEl = helpers.q('h1, h1 span, .series-title, .text-3xl, .font-bold.text-white');
+    if (titleEl) {
+      data.title = {
+        selector: titleEl.className || titleEl.tagName,
+        text: helpers.safeText(titleEl),
+        html: titleEl.outerHTML,
+      };
+    }
+    const poster = helpers.q('img[src*="poster"], img[src*="cover"], .lazyload');
+    if (poster) {
+      data.poster = {
+        selector: poster.className || poster.tagName,
+        src: helpers.absUrl(poster.getAttribute('src')),
+        html: poster.outerHTML,
+      };
+    }
+    const description = helpers.q('.text-gray-200.text-sm, .description, .line-clamp-4');
+    if (description) {
+      data.description = {
+        selector: description.className,
+        text: helpers.safeText(description),
+        html: description.outerHTML,
+      };
+    }
+    const genres = helpers
+      .qAll('a[href*="tur"], a[href*="genre"], .bg-gray-800, .bg-gray-900')
+      .filter((el) => helpers.safeText(el)?.length);
+    if (genres.length) {
+      data.genres = genres.map((el) => ({
+        text: helpers.safeText(el),
+        href: helpers.absUrl(el.getAttribute('href')),
+        className: el.className,
+      }));
+    }
+    const episodes = helpers
+      .qAll('a[href*="/bolum"], a[href*="/episode"], a[href*="/sezon/"]')
+      .map((link) => ({
+        href: helpers.absUrl(link.getAttribute('href')),
+        text: helpers.safeText(link),
+        className: link.className,
+      }));
+    if (episodes.length) data.episodeLinks = episodes;
+    info.overview = data;
+  }
+
+  function collectEpisode(info) {
+    if (!/bolum|episode/i.test(location.href)) return;
+    const data = {};
+    const title = helpers.q('h1, .text-xl.font-semibold, .episode-title');
+    if (title) {
+      data.title = {
+        text: helpers.safeText(title),
+        className: title.className,
+        html: title.outerHTML,
+      };
+    }
+    const subtitle = helpers.q('h2, .text-sm.text-white, .text-gray-200');
+    if (subtitle) {
+      data.subtitle = {
+        text: helpers.safeText(subtitle),
+        className: subtitle.className,
+        html: subtitle.outerHTML,
+      };
+    }
+    const overviewLink = helpers.q('a[href*="/dizi/"], nav a[href*="/dizi/"]');
+    if (overviewLink) {
+      data.overviewLink = {
+        href: helpers.absUrl(overviewLink.getAttribute('href')),
+        text: helpers.safeText(overviewLink),
+        className: overviewLink.className,
+      };
+    }
+    const nextLink = helpers.q('a[rel="next"], .next a[href], a[href*="bolum"][href*="next"]');
+    if (nextLink) {
+      data.next = {
+        href: helpers.absUrl(nextLink.getAttribute('href')),
+        text: helpers.safeText(nextLink),
+      };
+    }
+    data.breadcrumbs = helpers.qAll('nav a, .breadcrumbs a').map((a) => ({
+      text: helpers.safeText(a),
+      href: helpers.absUrl(a.getAttribute('href')),
+    }));
+    info.episode = data;
+  }
+
+  function collectPlayer(info) {
+    // Simplified player collection focusing on iframe
+    const iframePlayers = helpers.qAll('iframe[src*="pichive.online"]');
+    if (iframePlayers.length) {
+      info.player = iframePlayers.map((el, index) => ({
+        index,
+        tag: el.tagName.toLowerCase(),
+        src: el.src || null,
+        className: el.className || null,
+        id: el.id || null,
+      }));
+    } else {
+      // Fallback to video elements if no iframe found
+      info.player = helpers.qAll('video, source').map((el, index) => ({
+        index,
+        tag: el.tagName.toLowerCase(),
+        src: el.getAttribute('src') || el.currentSrc || null,
+        className: el.className || null,
+        id: el.id || null,
+      }));
+    }
+  }
+
+  function renderOverlay(info) {
+    const existing = document.getElementById('malsync-diziwatch-overlay');
+    if (existing) existing.remove();
+
+    const container = document.createElement('div');
+    container.id = 'malsync-diziwatch-overlay';
+    container.style.cssText = [
+      'position:fixed',
+      'top:10px',
+      'right:10px',
+      'z-index:2147483647',
+      'background:rgba(0,0,0,0.92)',
+      'color:#fff',
+      'padding:12px',
+      'border-radius:6px',
+      'font-family:Consolas,monospace',
+      'font-size:12px',
+      'max-width:420px',
+      'max-height:85vh',
+      'overflow:auto',
+      'box-shadow:0 0 12px rgba(0,0,0,0.4)',
+    ].join(';');
+
+    const buttons = document.createElement('div');
+    buttons.style.cssText = 'margin-bottom:6px;display:flex;gap:8px;justify-content:flex-end;';
+    const copyBtn = document.createElement('button');
+    copyBtn.textContent = 'Copy JSON';
+    copyBtn.style.cssText = 'background:#26a69a;border:none;color:#fff;padding:6px 10px;border-radius:4px;cursor:pointer;';
+    copyBtn.onclick = () => navigator.clipboard.writeText(JSON.stringify(info, null, 2));
+    const refreshBtn = document.createElement('button');
+    refreshBtn.textContent = 'Refresh';
+    refreshBtn.style.cssText = 'background:#42a5f5;border:none;color:#fff;padding:6px 10px;border-radius:4px;cursor:pointer;';
+    refreshBtn.onclick = () => {
+      container.remove();
+      setTimeout(runInspector, 100);
+    };
+    buttons.append(copyBtn, refreshBtn);
+    container.appendChild(buttons);
+
+    const header = document.createElement('div');
+    header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;';
+    header.innerHTML = `<strong>MALSync Inspector</strong><button style="background:#ff5252;border:none;color:#fff;width:22px;height:22px;border-radius:50%;cursor:pointer">✕</button>`;
+    header.querySelector('button').onclick = () => container.remove();
+    container.appendChild(header);
+
+    const pre = document.createElement('pre');
+    pre.textContent = JSON.stringify(info, null, 2);
+    pre.style.whiteSpace = 'pre-wrap';
+    container.appendChild(pre);
+
+    document.body.appendChild(container);
+  }
+
+  function runInspector() {
+    const info = {};
+    collectBasics(info);
+    collectOverview(info);
+    collectEpisode(info);
+    collectPlayer(info);
+    renderOverlay(info);
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    runInspector();
+  } else {
+    document.addEventListener('DOMContentLoaded', runInspector);
+  }
+
+  const observer = new MutationObserver(() => {
+    clearTimeout(window.__malsyncInspectorTimer);
+    window.__malsyncInspectorTimer = setTimeout(runInspector, 1000);
+  });
+  observer.observe(document.documentElement || document.body, { childList: true, subtree: true });
+})();

--- a/src/pages-chibi/implementations/Diziwatch/main.ts
+++ b/src/pages-chibi/implementations/Diziwatch/main.ts
@@ -1,0 +1,443 @@
+import { PageInterface } from '../../pageInterface';
+
+declare const chrome: any | undefined;
+declare const browser: any | undefined;
+declare const api: any | undefined;
+
+const EPISODE_TITLE_SELECTOR = '#router-view .col-span-7 h2.text-sm.text-white';
+const OVERVIEW_TITLE_SELECTOR = '#router-view h2.text-sm.text-white';
+const OVERVIEW_CONTAINER_SELECTOR = '#router-view .boxitm';
+const PLAYER_CONTAINER_SELECTOR = '#player-video';
+const EPISODE_LINK_SELECTOR = '#router-view .sm\\:col-span-3 a[href*="/bolum-"]';
+const NEXT_EP_SELECTOR = '.col-span-7 a[href*="/bolum-"]';
+const VIDEO_BRIDGE_FLAG = '__malsync_diziwatch_bridge';
+
+const STORAGE_CURRENT_KEY = 'pubplus_currentTime';
+const STORAGE_DURATION_KEY = 'pubplus_duration';
+
+// iframe selector for pichive player
+const IFRAME_SELECTOR = 'iframe[src*="pichive.online"]';
+
+type BridgeState = {
+  lastMsgType?: string;
+  lastSent?: { current: number; duration: number; paused: boolean };
+  lastSampleCurrent?: number;
+  lastSampleDuration?: number;
+  lastSampleTs?: number;
+  playerDetected?: boolean;
+  iframeSrc?: string;
+  messageListenerAdded?: boolean;
+  // Player state for iframe integration
+  currentTime?: number;
+  duration?: number;
+  paused?: boolean;
+  isIframeReady?: boolean;
+};
+
+function parseFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return undefined;
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function forwardTime(state: BridgeState, current: number, duration: number, paused: boolean) {
+  if (!Number.isFinite(current) || !Number.isFinite(duration) || duration <= 0) return;
+
+  const last = state.lastSent;
+  if (
+    last &&
+    Math.abs(last.current - current) < 0.05 &&
+    Math.abs(last.duration - duration) < 0.05 &&
+    last.paused === paused
+  ) {
+    return;
+  }
+
+  state.lastSent = { current, duration, paused };
+  state.lastSampleCurrent = current;
+  state.lastSampleDuration = duration;
+  state.lastSampleTs = Date.now();
+  sendVideoTime({ current, duration, paused });
+}
+
+function startStoragePolling(state: BridgeState) {
+  if (typeof window === 'undefined') return;
+
+  const poll = () => {
+    try {
+      if (!window.localStorage) return;
+    } catch (error) {
+      return;
+    }
+
+    let currentRaw: string | null = null;
+    let durationRaw: string | null = null;
+    try {
+      currentRaw = window.localStorage.getItem(STORAGE_CURRENT_KEY);
+      durationRaw = window.localStorage.getItem(STORAGE_DURATION_KEY);
+    } catch (error) {
+      return;
+    }
+
+    const current = parseFiniteNumber(currentRaw);
+    const duration = parseFiniteNumber(durationRaw);
+    if (current === undefined || duration === undefined || duration <= 0) return;
+
+    const prevCurrent = state.lastSampleCurrent;
+    const delta = typeof prevCurrent === 'number' ? current - prevCurrent : undefined;
+    const hasMeaningfulProgress = typeof delta === 'number' && Math.abs(delta) > 0.05;
+
+    if (hasMeaningfulProgress) {
+      state.lastMsgType =
+        state.lastMsgType === 'paused' || state.lastMsgType === 'error'
+          ? 'playing'
+          : state.lastMsgType;
+    }
+
+    const paused =
+      state.lastMsgType === 'paused' ||
+      state.lastMsgType === 'error' ||
+      (typeof delta === 'number' && Math.abs(delta) < 0.05);
+
+    forwardTime(state, current, duration, paused);
+  };
+
+  poll();
+  const intervalId = window.setInterval(poll, 1000);
+
+  // Player detection and enhanced polling
+  const playerCheckInterval = window.setInterval(() => {
+    const playerContainer = document.querySelector('#player-video');
+    if (playerContainer && playerContainer.querySelector(IFRAME_SELECTOR)) {
+      const iframe = playerContainer.querySelector(IFRAME_SELECTOR) as HTMLIFrameElement;
+      const iframeSrc = iframe?.src;
+
+      if (!state.playerDetected) {
+        state.playerDetected = true;
+        state.iframeSrc = iframeSrc;
+        state.isIframeReady = false;
+        console.log('[MALSync][Diziwatch] Player detected with src:', iframeSrc);
+
+        // Add message listener when player is detected
+        if (!state.messageListenerAdded) {
+          addPlayerMessageListener(state);
+          state.messageListenerAdded = true;
+        }
+      } else if (state.iframeSrc !== iframeSrc) {
+        // If iframe src changed, update it and re-add listener
+        state.iframeSrc = iframeSrc;
+        state.isIframeReady = false;
+        console.log('[MALSync][Diziwatch] Player iframe src changed to:', iframeSrc);
+
+        if (!state.messageListenerAdded) {
+          addPlayerMessageListener(state);
+          state.messageListenerAdded = true;
+        }
+      }
+    } else if (state.playerDetected) {
+      // Player removed, clear state
+      state.playerDetected = false;
+      state.iframeSrc = undefined;
+      state.isIframeReady = false;
+      state.lastMsgType = undefined;
+      state.lastSent = undefined;
+      console.log('[MALSync][Diziwatch] Player removed');
+    }
+  }, 3000);
+}
+
+function addPlayerMessageListener(state: BridgeState) {
+  // Listen for player events through postMessage
+  const messageHandler = (event: MessageEvent) => {
+    try {
+      if (event.data && typeof event.data === 'object') {
+        // Handle DiziWatch specific player messages
+        if (event.data.msgVer === '2' || event.data.msgVer === 2) {
+          const time = parseFiniteNumber(event.data?.timeInfo?.time);
+          const duration = parseFiniteNumber(event.data?.timeInfo?.duration);
+
+          if (time !== undefined && duration !== undefined && duration > 0) {
+            const paused = event.data.msgType === 'paused' || event.data.msgType === 'error';
+            forwardTime(state, time, duration, paused);
+
+            // Update player state
+            state.currentTime = time;
+            state.duration = duration;
+            state.paused = paused;
+            state.isIframeReady = true;
+
+            // Send message to parent window for iframe integration
+            window.parent.postMessage(
+              {
+                type: 'MALSyncPlayerTime',
+                current: time,
+                duration,
+                paused,
+              },
+              '*',
+            );
+
+            // Update last message type
+            if (typeof event.data.msgType === 'string') {
+              state.lastMsgType = event.data.msgType;
+            }
+          }
+        }
+
+        // Handle generic player messages
+        if (event.data.currentTime !== undefined && event.data.duration !== undefined) {
+          const current = parseFiniteNumber(event.data.currentTime);
+          const duration = parseFiniteNumber(event.data.duration);
+          if (current !== undefined && duration !== undefined && duration > 0) {
+            const paused = event.data.paused === true;
+            forwardTime(state, current, duration, paused);
+
+            // Update player state
+            state.currentTime = current;
+            state.duration = duration;
+            state.paused = paused;
+            state.isIframeReady = true;
+
+            // Send message to parent window for iframe integration
+            window.parent.postMessage(
+              {
+                type: 'MALSyncPlayerTime',
+                current,
+                duration,
+                paused,
+              },
+              '*',
+            );
+          }
+        }
+
+        // Handle alternative time formats
+        if (event.data.time !== undefined && event.data.totalTime !== undefined) {
+          const current = parseFiniteNumber(event.data.time);
+          const duration = parseFiniteNumber(event.data.totalTime);
+          if (current !== undefined && duration !== undefined && duration > 0) {
+            const paused = event.data.paused === true;
+            forwardTime(state, current, duration, paused);
+
+            // Update player state
+            state.currentTime = current;
+            state.duration = duration;
+            state.paused = paused;
+            state.isIframeReady = true;
+
+            // Send message to parent window for iframe integration
+            window.parent.postMessage(
+              {
+                type: 'MALSyncPlayerTime',
+                current,
+                duration,
+                paused,
+              },
+              '*',
+            );
+          }
+        }
+      }
+    } catch (e) {
+      console.debug('[MALSync][Diziwatch] Error processing player message', e);
+    }
+  };
+
+  window.addEventListener('message', messageHandler);
+  console.log('[MALSync][Diziwatch] Added player message listener');
+}
+
+function sendVideoTime(payload: { current: number; duration: number; paused: boolean }) {
+  try {
+    if (typeof chrome !== 'undefined' && chrome?.runtime?.sendMessage) {
+      chrome.runtime.sendMessage({ name: 'videoTime', item: payload });
+      return;
+    }
+    if (typeof browser !== 'undefined' && browser?.runtime?.sendMessage) {
+      browser.runtime.sendMessage({ name: 'videoTime', item: payload });
+      return;
+    }
+    if (typeof api !== 'undefined' && api?.request?.sendMessage) {
+      api.request.sendMessage({ name: 'videoTime', item: payload });
+    }
+  } catch (error) {
+    console.error('[MALSync][Diziwatch] Failed to forward videoTime', error);
+  }
+}
+
+function setupPichiveBridge() {
+  if (typeof window === 'undefined') return;
+  const globalScope = window as typeof window & { [VIDEO_BRIDGE_FLAG]?: boolean };
+  if (globalScope[VIDEO_BRIDGE_FLAG]) return;
+  globalScope[VIDEO_BRIDGE_FLAG] = true;
+
+  const state: BridgeState = {};
+  startStoragePolling(state);
+
+  // Enhanced player detection for iframe-based players
+  const detectPlayer = () => {
+    const playerContainer = document.querySelector('#player-video');
+    if (playerContainer) {
+      // Check for iframe player
+      const iframe = playerContainer.querySelector(IFRAME_SELECTOR) as HTMLIFrameElement;
+      if (iframe && iframe.src) {
+        state.playerDetected = true;
+        state.iframeSrc = iframe.src;
+        state.isIframeReady = false;
+        console.log('[MALSync][Diziwatch] Player detected on load with src:', iframe.src);
+
+        // Add message listener
+        if (!state.messageListenerAdded) {
+          addPlayerMessageListener(state);
+          state.messageListenerAdded = true;
+        }
+      }
+    }
+  };
+
+  // Run player detection after DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', detectPlayer);
+  } else {
+    detectPlayer();
+  }
+
+  // Also listen for player messages at the global level
+  window.addEventListener('message', event => {
+    const data = event.data;
+    if (!data || typeof data !== 'object') return;
+
+    // Handle DiziWatch specific messages
+    const versionCheck = data.msgVer === '2' || data.msgVer === 2;
+    if (versionCheck) {
+      if (typeof data.msgType === 'string') {
+        state.lastMsgType = data.msgType;
+      }
+
+      const time = parseFiniteNumber(data?.timeInfo?.time);
+      const duration = parseFiniteNumber(data?.timeInfo?.duration);
+
+      if (time !== undefined && duration !== undefined && duration > 0) {
+        const paused = data.msgType === 'paused' || data.msgType === 'error';
+        forwardTime(state, time, duration, paused);
+
+        // Update player state
+        state.currentTime = time;
+        state.duration = duration;
+        state.paused = paused;
+        state.isIframeReady = true;
+
+        if (data.msgType === 'watched') {
+          forwardTime(state, duration, duration, true);
+        }
+      }
+    }
+  });
+}
+
+export const Diziwatch: PageInterface = {
+  name: 'Diziwatch',
+  type: 'anime',
+  domain: 'https://diziwatch.tv',
+  languages: ['Turkish'],
+  urls: {
+    match: ['*://*.diziwatch.tv/*'],
+  },
+  sync: {
+    isSyncPage($c) {
+      return $c.url().regex('dizi/[^/]+/sezon-\\d+/bolum-\\d+', 0).boolean().run();
+    },
+    getTitle($c) {
+      return $c
+        .querySelector(EPISODE_TITLE_SELECTOR)
+        .ifNotReturn()
+        .text()
+        .trim()
+        .replaceRegex('\\s+\\d+\\.\\s*Sezon.*$', '')
+        .replaceRegex('\\s+Season\\s*\\d+.*$', '')
+        .run();
+    },
+    getIdentifier($c) {
+      return $c.url().regex('dizi/([^/?#]+)', 1).run();
+    },
+    getOverviewUrl($c) {
+      return $c.url().regex('(https://diziwatch\\.tv/dizi/[^/?#]+)', 1).run();
+    },
+    getEpisode($c) {
+      return $c.url().regex('bolum-(\\d+)', 1).number().run();
+    },
+    nextEpUrl($c) {
+      return $c
+        .querySelector(NEXT_EP_SELECTOR)
+        .ifNotReturn()
+        .getAttribute('href')
+        .urlAbsolute()
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector(PLAYER_CONTAINER_SELECTOR).ifNotReturn().uiBefore().run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c
+        .and(
+          $c.url().regex('dizi/[^/]+(?:/sezon-\\d+)?/?$', 0).boolean().run(),
+          $c.url().contains('/bolum-').not().run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return $c
+        .querySelector(OVERVIEW_TITLE_SELECTOR)
+        .ifNotReturn()
+        .text()
+        .trim()
+        .replaceRegex('\\s+\\d+\\.\\s*Sezon.*$', '')
+        .replaceRegex('\\s+Season\\s*\\d+.*$', '')
+        .run();
+    },
+    getIdentifier($c) {
+      return $c.url().regex('dizi/([^/?#]+)', 1).run();
+    },
+    getImage($c) {
+      return $c
+        .querySelector('#router-view img.aspect-\\[30/40\\], #router-view img.lazyload')
+        .ifNotReturn()
+        .getAttribute('src')
+        .urlAbsolute()
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector(OVERVIEW_CONTAINER_SELECTOR).ifNotReturn().uiAfter().run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll(EPISODE_LINK_SELECTOR).run();
+    },
+    elementUrl($c) {
+      return $c.getAttribute('href').urlAbsolute().run();
+    },
+    elementEp($c) {
+      return $c.this('list.elementUrl').this('sync.getEpisode').run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      setupPichiveBridge();
+      return $c.domReady().trigger().detectURLChanges($c.trigger().run()).run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/Diziwatch/style.less
+++ b/src/pages-chibi/implementations/Diziwatch/style.less
@@ -1,0 +1,29 @@
+@import './../pages';
+
+#malsync-container {
+  margin: 16px 0;
+  padding: 12px;
+  background: rgb(0 0 0 / 8%);
+  border-radius: 6px;
+}
+
+.malsync-button {
+  background: #1e88e5;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background-color 0.2s;
+}
+
+.malsync-button:hover {
+  background: #1669b4;
+}
+
+[data-theme='dark'] #malsync-container,
+.dark #malsync-container {
+  background: rgb(255 255 255 / 8%);
+}

--- a/src/pages-chibi/implementations/Diziwatch/tests.json
+++ b/src/pages-chibi/implementations/Diziwatch/tests.json
@@ -1,0 +1,32 @@
+{
+  "title": "Diziwatch",
+  "url": "https://diziwatch.tv",
+  "testCases": [
+    {
+      "url": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero",
+      "expected": {
+        "sync": false,
+        "title": "The Rising of the Shield Hero",
+        "identifier": "the-rising-of-the-shield-hero",
+        "image": "https://images.macellan.online/images/tv/poster/180/270/80/b47b8eeoqpoq8wa1162b07a5.jpg",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero/sezon-1/bolum-1",
+          "2": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero/sezon-1/bolum-2"
+        }
+      }
+    },
+    {
+      "url": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero/sezon-1/bolum-1",
+      "expected": {
+        "sync": true,
+        "title": "The Rising of the Shield Hero",
+        "identifier": "the-rising-of-the-shield-hero",
+        "overviewUrl": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero",
+        "nextEpUrl": "https://diziwatch.tv/dizi/the-rising-of-the-shield-hero/sezon-1/bolum-2",
+        "episode": 1,
+        "uiSelector": false
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -19,10 +19,12 @@ import { WeebCentral } from './implementations/WeebCentral/main';
 import { MangaDemon } from './implementations/MangaDemon/main';
 import { RoliaScan } from './implementations/RoliaScan/main';
 import { Mangitto } from './implementations/Mangitto/main';
+import { Animecix } from './implementations/Animecix/main';
 import { Anizium } from './implementations/Anizium/main';
 import { Miruro } from './implementations/Miruro/main';
 import { MangaPark } from './implementations/MangaPark/main';
 import { Q1N } from './implementations/Q1N/main';
+import { Diziwatch } from './implementations/Diziwatch/main';
 
 export const pages: { [key: string]: PageInterface } = {
   animeav1,
@@ -44,8 +46,10 @@ export const pages: { [key: string]: PageInterface } = {
   MangaDemon,
   RoliaScan,
   Mangitto,
+  Animecix,
   Anizium,
   Miruro,
   MangaPark,
   Q1N,
+  Diziwatch,
 };

--- a/src/pages/list.json
+++ b/src/pages/list.json
@@ -1,40 +1,5 @@
 [
   {
-    "domain": "https://www.mangadex.org",
-    "type": "manga",
-    "name": "Mangadex"
-  },
-  {
-    "domain": "https://www.turkanime.co",
-    "type": "anime",
-    "name": "TurkAnime"
-  },
-  {
-    "domain": "https://animepahe.com",
-    "type": "anime",
-    "name": "animepahe"
-  },
-  {
-    "domain": "https://www.netflix.com",
-    "type": "anime",
-    "name": "Netflix"
-  },
-  {
-    "domain": "https://animeflv.net",
-    "type": "anime",
-    "name": "Animeflv"
-  },
-  {
-    "domain": "https://jkanime.net",
-    "type": "anime",
-    "name": "Jkanime"
-  },
-  {
-    "domain": "https://proxer.me",
-    "type": "anime",
-    "name": "Proxer"
-  },
-  {
     "domain": "http://app.emby.media",
     "type": "anime",
     "name": "Emby"
@@ -45,159 +10,9 @@
     "name": "Plex"
   },
   {
-    "domain": "https://aniflix.cc",
-    "type": "anime",
-    "name": "Aniflix"
-  },
-  {
-    "domain": "https://kickassanime.am",
-    "type": "anime",
-    "name": "KickAssAnime"
-  },
-  {
-    "domain": "https://shinden.pl",
-    "type": "anime",
-    "name": "Shinden"
-  },
-  {
-    "domain": "https://voiranime.com",
-    "type": "anime",
-    "name": "Voiranime"
-  },
-  {
-    "domain": "https://www.viz.com",
-    "type": "manga",
-    "name": "VIZ"
-  },
-  {
-    "domain": "https://anime-odcinki.pl",
-    "type": "anime",
-    "name": "AnimeOdcinki"
-  },
-  {
-    "domain": "https://www.animezone.pl",
-    "type": "anime",
-    "name": "AnimeZone"
-  },
-  {
-    "domain": "https://serimanga.com",
-    "type": "manga",
-    "name": "serimanga"
-  },
-  {
-    "domain": "https://www.mangadenizi.net",
-    "type": "manga",
-    "name": "mangadenizi"
-  },
-  {
-    "domain": "https://moeclip.com",
-    "type": "anime",
-    "name": "moeclip"
-  },
-  {
-    "domain": "https://mangalivre.net",
-    "type": "manga",
-    "name": "Mangá Livre"
-  },
-  {
-    "domain": "https://zonatmo.com",
-    "type": "manga",
-    "name": "tmofans"
-  },
-  {
-    "domain": "https://mangaplus.shueisha.co.jp",
-    "type": "manga",
-    "name": "MangaPlus"
-  },
-  {
-    "domain": "https://www.japscan.ws",
-    "type": "manga",
-    "name": "JapScan"
-  },
-  {
-    "domain": "https://www.hulu.com",
-    "type": "anime",
-    "name": "Hulu"
-  },
-  {
-    "domain": "https://www.hidive.com",
-    "type": "anime",
-    "name": "Hidive"
-  },
-  {
     "domain": "http://mangakatana.com",
     "type": "manga",
     "name": "MangaKatana"
-  },
-  {
-    "domain": "https://manga4life.com",
-    "type": "manga",
-    "name": "manga4life"
-  },
-  {
-    "domain": "https://animexin.vip",
-    "type": "anime",
-    "name": "AnimeXin"
-  },
-  {
-    "domain": "https://monoschinos2.com",
-    "type": "anime",
-    "name": "MonosChinos"
-  },
-  {
-    "domain": "https://smotret-anime.org",
-    "type": "anime",
-    "name": "Anime365"
-  },
-  {
-    "domain": "https://animefire.net",
-    "type": "anime",
-    "name": "AnimeFire"
-  },
-  {
-    "domain": "https://otakufr.cc",
-    "type": "anime",
-    "name": "OtakuFR"
-  },
-  {
-    "domain": "https://mangatx.com",
-    "type": "manga",
-    "name": "mangatx"
-  },
-  {
-    "domain": "https://manhuafast.com",
-    "type": "manga",
-    "name": "manhuafast"
-  },
-  {
-    "domain": "https://www.tranimeizle.net/",
-    "type": "anime",
-    "name": "TRanimeizle"
-  },
-  {
-    "domain": "https://beta.animestreamingfr.fr",
-    "type": "anime",
-    "name": "AnimeStreamingFR"
-  },
-  {
-    "domain": "https://furyosociety.com/",
-    "type": "manga",
-    "name": "Furyosociety"
-  },
-  {
-    "domain": "https://www.animeid.tv",
-    "type": "anime",
-    "name": "AnimeId"
-  },
-  {
-    "domain": "https://myanimelist.net",
-    "type": "anime",
-    "name": "MyAnimeList"
-  },
-  {
-    "domain": "https://animeunity.it",
-    "type": "anime",
-    "name": "AnimeUnity"
   },
   {
     "domain": "http://www.mangahere.cc",
@@ -205,439 +20,9 @@
     "name": "MangaHere"
   },
   {
-    "domain": "https://fanfox.net",
-    "type": "manga",
-    "name": "MangaFox"
-  },
-  {
-    "domain": "https://desu-online.pl",
-    "type": "anime",
-    "name": "DesuOnline"
-  },
-  {
-    "domain": "https://wuxiaworld.site",
-    "type": "manga",
-    "name": "WuxiaWorld"
-  },
-  {
-    "domain": "https://lscomic.com",
-    "type": "manga",
-    "name": "LeviatanScans"
-  },
-  {
-    "domain": "https://reaperscans.com",
-    "type": "manga",
-    "name": "ReaperScans"
-  },
-  {
-    "domain": "https://lynxscans.com",
-    "type": "manga",
-    "name": "LynxScans"
-  },
-  {
-    "domain": "https://zeroscans.com",
-    "type": "manga",
-    "name": "ZeroScans"
-  },
-  {
-    "domain": "https://reader.deathtollscans.net",
-    "type": "manga",
-    "name": "DeathTollScans"
-  },
-  {
-    "domain": "https://manhuaplus.com",
-    "type": "manga",
-    "name": "ManhuaPlus"
-  },
-  {
-    "domain": "https://readm.today",
-    "type": "manga",
-    "name": "Readm"
-  },
-  {
-    "domain": "https://tioanime.com",
-    "type": "anime",
-    "name": "tioanime"
-  },
-  {
-    "domain": "https://mangasee123.com",
-    "type": "manga",
-    "name": "MangaSee"
-  },
-  {
-    "domain": "https://okanime.tv",
-    "type": "anime",
-    "name": "Okanime"
-  },
-  {
-    "domain": "https://bs.to",
-    "type": "anime",
-    "name": "bs.to"
-  },
-  {
-    "domain": "https://asuratoon.com",
-    "type": "manga",
-    "name": "AsuraScans"
-  },
-  {
-    "domain": "https://jellyfin.org/",
-    "type": "anime",
-    "name": "Jellyfin"
-  },
-  {
     "domain": "https://an1me.to",
     "type": "anime",
     "name": "An1me"
-  },
-  {
-    "domain": "https://mangajar.pro",
-    "type": "manga",
-    "name": "MangaJar"
-  },
-  {
-    "domain": "https://www.otakustv.com",
-    "type": "anime",
-    "name": "Otakustv"
-  },
-  {
-    "domain": "https://komga.org",
-    "type": "manga",
-    "name": "Komga"
-  },
-  {
-    "domain": "https://animewho.com",
-    "type": "anime",
-    "name": "AnimeWho"
-  },
-  {
-    "domain": "https://fumetsu.pl",
-    "type": "anime",
-    "name": "Fumetsu"
-  },
-  {
-    "domain": "https://frixysubs.pl",
-    "type": "anime",
-    "name": "FrixySubs"
-  },
-  {
-    "domain": "https://guya.moe",
-    "type": "manga",
-    "name": "Guya & Cubari"
-  },
-  {
-    "domain": "https://mangahub.io",
-    "type": "manga",
-    "name": "MangaHub"
-  },
-  {
-    "domain": "https://bentomanga.com",
-    "type": "manga",
-    "name": "Bentomanga"
-  },
-  {
-    "domain": "https://mangasushi.net",
-    "type": "manga",
-    "name": "MangaSushi"
-  },
-  {
-    "domain": "https://tritinia.com",
-    "type": "manga",
-    "name": "TritiniaScans"
-  },
-  {
-    "domain": "https://readmanhua.net",
-    "type": "manga",
-    "name": "ReadManhua"
-  },
-  {
-    "domain": "https://flamecomics.xyz",
-    "type": "manga",
-    "name": "FlameScans"
-  },
-  {
-    "domain": "https://immortalupdates.com",
-    "type": "manga",
-    "name": "ImmortalUpdates"
-  },
-  {
-    "domain": "https://hianime.to",
-    "type": "anime",
-    "name": "HiAnime"
-  },
-  {
-    "domain": "https://beta.kitsune.tv",
-    "type": "anime",
-    "name": "Kitsune"
-  },
-  {
-    "domain": "https://lhtranslation.net",
-    "type": "manga",
-    "name": "LHTranslation"
-  },
-  {
-    "domain": "https://mangas-origines.fr/",
-    "type": "manga",
-    "name": "MangasOrigines"
-  },
-  {
-    "domain": "https://www.bluesolo.org",
-    "type": "manga",
-    "name": "BlueSolo"
-  },
-  {
-    "domain": "https://disasterscans.com",
-    "type": "manga",
-    "name": "DisasterScans"
-  },
-  {
-    "domain": "https://dynasty-scans.com",
-    "type": "manga",
-    "name": "DynastyScans"
-  },
-  {
-    "domain": "https://aniworld.to",
-    "type": "anime",
-    "name": "Aniworld"
-  },
-  {
-    "domain": "https://betteranime.net",
-    "type": "anime",
-    "name": "BetterAnime"
-  },
-  {
-    "domain": "https://manga.bilibili.com",
-    "type": "manga",
-    "name": "BilibiliComics"
-  },
-  {
-    "domain": "https://mangareader.to",
-    "type": "manga",
-    "name": "MangaReader"
-  },
-  {
-    "domain": "https://animeonsen.xyz",
-    "type": "anime",
-    "name": "AnimeOnsen"
-  },
-  {
-    "domain": "https://www.animetoast.cc",
-    "type": "anime",
-    "name": "Animetoast"
-  },
-  {
-    "domain": "https://luminous-scans.com",
-    "type": "manga",
-    "name": "LuminousScans"
-  },
-  {
-    "domain": "https://www.animeworld.tv",
-    "type": "anime",
-    "name": "Animeworld"
-  },
-  {
-    "domain": "https://mangabuddy.com",
-    "type": "manga",
-    "name": "MangaBuddy"
-  },
-  {
-    "domain": "https://vvww.toonanime.cc",
-    "type": "anime",
-    "name": "ToonAnime"
-  },
-  {
-    "domain": "https://www.adkami.com/",
-    "type": "anime",
-    "name": "ADKami"
-  },
-  {
-    "domain": "https://kaguya.app",
-    "type": "anime",
-    "name": "Kaguya"
-  },
-  {
-    "domain": "https://hdrezka.ag",
-    "type": "anime",
-    "name": "Hdrezka"
-  },
-  {
-    "domain": "https://sovetromantica.com",
-    "type": "anime",
-    "name": "SovetRomantica"
-  },
-  {
-    "domain": "https://animationdigitalnetwork.com",
-    "type": "anime",
-    "name": "ADN"
-  },
-  {
-    "domain": "https://aniyan.net",
-    "type": "anime",
-    "name": "Aniyan"
-  },
-  {
-    "domain": "https://docchi.pl",
-    "type": "anime",
-    "name": "Docchi"
-  },
-  {
-    "domain": "https://franime.fr",
-    "type": "anime",
-    "name": "FRAnime"
-  },
-  {
-    "domain": "https://fmteam.fr",
-    "type": "manga",
-    "name": "FMTeam"
-  },
-  {
-    "domain": "https://www.animelon.com",
-    "type": "anime",
-    "name": "Animelon"
-  },
-  {
-    "domain": "https://animenosub.to",
-    "type": "anime",
-    "name": "AnimeNoSub"
-  },
-  {
-    "domain": "https://anime-sama.fr",
-    "type": "anime",
-    "name": "AnimeSama"
-  },
-  {
-    "domain": "https://mangafire.to",
-    "type": "manga",
-    "name": "MangaFire"
-  },
-  {
-    "domain": "https://projectsuki.com",
-    "type": "manga",
-    "name": "projectsuki"
-  },
-  {
-    "domain": "https://animebuff.ru",
-    "type": "anime",
-    "name": "AnimeBuff"
-  },
-  {
-    "domain": "https://www.animeonegai.com",
-    "type": "anime",
-    "name": "AnimeOnegai"
-  },
-  {
-    "domain": "https://animeko.co",
-    "type": "anime",
-    "name": "AnimeKO"
-  },
-  {
-    "domain": "https://animego.org",
-    "type": "anime",
-    "name": "AnimeGO"
-  },
-  {
-    "domain": "https://luciferdonghua.in",
-    "type": "anime",
-    "name": "Lucifer Donghua"
-  },
-  {
-    "domain": "https://neoxscans.com/",
-    "type": "manga",
-    "name": "NeoxScans"
-  },
-  {
-    "domain": "https://hinatasoul.com",
-    "type": "anime",
-    "name": "HinataSoul"
-  },
-  {
-    "domain": "https://ogladajanime.pl",
-    "type": "anime",
-    "name": "OgladajAnime"
-  },
-  {
-    "domain": "https://hachi.moe",
-    "type": "manga",
-    "name": "hachi"
-  },
-  {
-    "domain": "https://witanime.pics",
-    "type": "anime",
-    "name": "WitAnime"
-  },
-  {
-    "domain": "https://suwayomi-webui-preview.github.io/",
-    "type": "manga",
-    "name": "Suwayomi"
-  },
-  {
-    "domain": "https://manhuaus.com",
-    "type": "manga",
-    "name": "ManhuaUS"
-  },
-  {
-    "domain": "https://taiyo.moe",
-    "type": "manga",
-    "name": "Taiyo"
-  },
-  {
-    "domain": "https://animesonline.in",
-    "type": "anime",
-    "name": "Animes Online"
-  },
-  {
-    "domain": "https://latanime.org",
-    "type": "anime",
-    "name": "Latanime"
-  },
-  {
-    "domain": "https://www.mangaread.org",
-    "type": "manga",
-    "name": "MangaRead"
-  },
-  {
-    "domain": "https://q1n.net",
-    "type": "anime",
-    "name": "Q1N"
-  },
-  {
-    "domain": "https://templescan.net",
-    "type": "manga",
-    "name": "TempleScan"
-  },
-  {
-    "domain": "https://scyllacomics.xyz",
-    "type": "manga",
-    "name": "ScyllaScans"
-  },
-  {
-    "domain": "https://vortexscans.org",
-    "type": "manga",
-    "name": "VortexScans"
-  },
-  {
-    "domain": "https://demo.kavitareader.com",
-    "type": "manga",
-    "name": "Kavita"
-  },
-  {
-    "domain": "https://rawkuma.com",
-    "type": "manga",
-    "name": "Rawkuma"
-  },
-  {
-    "domain": "https://aninexus.to",
-    "type": "anime",
-    "name": "Aninexus"
-  },
-  {
-    "domain": "https://anidream.cc",
-    "type": "anime",
-    "name": "AniDream"
-  },
-  {
-    "domain": "https://animeav1.com",
-    "type": "anime",
-    "name": "Animeav1"
   },
   {
     "domain": "https://anicrush.to",
@@ -645,14 +30,14 @@
     "name": "Anicrush"
   },
   {
-    "domain": "https://manganato.gg",
-    "type": "manga",
-    "name": "MangaNato"
+    "domain": "https://anidream.cc",
+    "type": "anime",
+    "name": "AniDream"
   },
   {
-    "domain": "https://animetsu.cc",
+    "domain": "https://aniflix.cc",
     "type": "anime",
-    "name": "Gojo"
+    "name": "Aniflix"
   },
   {
     "domain": "https://anilib.me",
@@ -660,49 +45,49 @@
     "name": "AnimeLib"
   },
   {
-    "domain": "https://mangalib.me",
-    "type": "manga",
-    "name": "MangaLib"
-  },
-  {
-    "domain": "https://ranobelib.me",
-    "type": "manga",
-    "name": "RanobeLib"
-  },
-  {
-    "domain": "https://anizm.net",
+    "domain": "https://animationdigitalnetwork.com",
     "type": "anime",
-    "name": "Anizm"
+    "name": "ADN"
   },
   {
-    "domain": "https://toonily.com",
-    "type": "manga",
-    "name": "Toonily"
-  },
-  {
-    "domain": "https://hivetoons.org",
-    "type": "manga",
-    "name": "VoidScans"
-  },
-  {
-    "domain": "https://anixl.to",
+    "domain": "https://anime-odcinki.pl",
     "type": "anime",
-    "name": "AniXL"
+    "name": "AnimeOdcinki"
   },
   {
-    "domain": "https://bato.to",
-    "type": "manga",
-    "name": "bato"
-  },
-  {
-    "domain": "https://www.crunchyroll.com",
+    "domain": "https://anime-sama.fr",
     "type": "anime",
-    "name": "Crunchyroll"
+    "name": "AnimeSama"
   },
   {
-    "domain": "https://animevost.org",
+    "domain": "https://animeav1.com",
     "type": "anime",
-    "name": "AnimeVost"
+    "name": "Animeav1"
+  },
+  {
+    "domain": "https://animebuff.ru",
+    "type": "anime",
+    "name": "AnimeBuff"
+  },
+  {
+    "domain": "https://animecix.tv",
+    "type": "anime",
+    "name": "Animecix"
+  },
+  {
+    "domain": "https://animefire.net",
+    "type": "anime",
+    "name": "AnimeFire"
+  },
+  {
+    "domain": "https://animeflv.net",
+    "type": "anime",
+    "name": "Animeflv"
+  },
+  {
+    "domain": "https://animego.org",
+    "type": "anime",
+    "name": "AnimeGO"
   },
   {
     "domain": "https://animekai.bz",
@@ -710,24 +95,74 @@
     "name": "AnimeKAI"
   },
   {
-    "domain": "https://weebcentral.com",
-    "type": "manga",
-    "name": "WeebCentral"
+    "domain": "https://animeko.co",
+    "type": "anime",
+    "name": "AnimeKO"
   },
   {
-    "domain": "https://demonicscans.org",
-    "type": "manga",
-    "name": "MangaDemon"
+    "domain": "https://animenosub.to",
+    "type": "anime",
+    "name": "AnimeNoSub"
   },
   {
-    "domain": "https://roliascan.com",
-    "type": "manga",
-    "name": "RoliaScan"
+    "domain": "https://animeonsen.xyz",
+    "type": "anime",
+    "name": "AnimeOnsen"
   },
   {
-    "domain": "https://mangtto.com",
-    "type": "manga",
-    "name": "Mangitto"
+    "domain": "https://animepahe.com",
+    "type": "anime",
+    "name": "animepahe"
+  },
+  {
+    "domain": "https://animesonline.in",
+    "type": "anime",
+    "name": "Animes Online"
+  },
+  {
+    "domain": "https://animetsu.cc",
+    "type": "anime",
+    "name": "Gojo"
+  },
+  {
+    "domain": "https://animeunity.it",
+    "type": "anime",
+    "name": "AnimeUnity"
+  },
+  {
+    "domain": "https://animevost.org",
+    "type": "anime",
+    "name": "AnimeVost"
+  },
+  {
+    "domain": "https://animewho.com",
+    "type": "anime",
+    "name": "AnimeWho"
+  },
+  {
+    "domain": "https://animexin.vip",
+    "type": "anime",
+    "name": "AnimeXin"
+  },
+  {
+    "domain": "https://aninexus.to",
+    "type": "anime",
+    "name": "Aninexus"
+  },
+  {
+    "domain": "https://aniworld.to",
+    "type": "anime",
+    "name": "Aniworld"
+  },
+  {
+    "domain": "https://anixl.to",
+    "type": "anime",
+    "name": "AniXL"
+  },
+  {
+    "domain": "https://aniyan.net",
+    "type": "anime",
+    "name": "Aniyan"
   },
   {
     "domain": "https://anizium.co",
@@ -735,13 +170,588 @@
     "name": "Anizium"
   },
   {
-    "domain": "https://www.miruro.to",
+    "domain": "https://anizm.net",
     "type": "anime",
-    "name": "Miruro"
+    "name": "Anizm"
+  },
+  {
+    "domain": "https://asuratoon.com",
+    "type": "manga",
+    "name": "AsuraScans"
+  },
+  {
+    "domain": "https://bato.to",
+    "type": "manga",
+    "name": "bato"
+  },
+  {
+    "domain": "https://bentomanga.com",
+    "type": "manga",
+    "name": "Bentomanga"
+  },
+  {
+    "domain": "https://beta.animestreamingfr.fr",
+    "type": "anime",
+    "name": "AnimeStreamingFR"
+  },
+  {
+    "domain": "https://beta.kitsune.tv",
+    "type": "anime",
+    "name": "Kitsune"
+  },
+  {
+    "domain": "https://betteranime.net",
+    "type": "anime",
+    "name": "BetterAnime"
+  },
+  {
+    "domain": "https://bs.to",
+    "type": "anime",
+    "name": "bs.to"
+  },
+  {
+    "domain": "https://demo.kavitareader.com",
+    "type": "manga",
+    "name": "Kavita"
+  },
+  {
+    "domain": "https://demonicscans.org",
+    "type": "manga",
+    "name": "MangaDemon"
+  },
+  {
+    "domain": "https://desu-online.pl",
+    "type": "anime",
+    "name": "DesuOnline"
+  },
+  {
+    "domain": "https://disasterscans.com",
+    "type": "manga",
+    "name": "DisasterScans"
+  },
+  {
+    "domain": "https://diziwatch.tv",
+    "type": "anime",
+    "name": "Diziwatch"
+  },
+  {
+    "domain": "https://docchi.pl",
+    "type": "anime",
+    "name": "Docchi"
+  },
+  {
+    "domain": "https://dynasty-scans.com",
+    "type": "manga",
+    "name": "DynastyScans"
+  },
+  {
+    "domain": "https://fanfox.net",
+    "type": "manga",
+    "name": "MangaFox"
+  },
+  {
+    "domain": "https://flamecomics.xyz",
+    "type": "manga",
+    "name": "FlameScans"
+  },
+  {
+    "domain": "https://fmteam.fr",
+    "type": "manga",
+    "name": "FMTeam"
+  },
+  {
+    "domain": "https://franime.fr",
+    "type": "anime",
+    "name": "FRAnime"
+  },
+  {
+    "domain": "https://frixysubs.pl",
+    "type": "anime",
+    "name": "FrixySubs"
+  },
+  {
+    "domain": "https://fumetsu.pl",
+    "type": "anime",
+    "name": "Fumetsu"
+  },
+  {
+    "domain": "https://furyosociety.com/",
+    "type": "manga",
+    "name": "Furyosociety"
+  },
+  {
+    "domain": "https://guya.moe",
+    "type": "manga",
+    "name": "Guya & Cubari"
+  },
+  {
+    "domain": "https://hachi.moe",
+    "type": "manga",
+    "name": "hachi"
+  },
+  {
+    "domain": "https://hdrezka.ag",
+    "type": "anime",
+    "name": "Hdrezka"
+  },
+  {
+    "domain": "https://hianime.to",
+    "type": "anime",
+    "name": "HiAnime"
+  },
+  {
+    "domain": "https://hinatasoul.com",
+    "type": "anime",
+    "name": "HinataSoul"
+  },
+  {
+    "domain": "https://hivetoons.org",
+    "type": "manga",
+    "name": "VoidScans"
+  },
+  {
+    "domain": "https://immortalupdates.com",
+    "type": "manga",
+    "name": "ImmortalUpdates"
+  },
+  {
+    "domain": "https://jellyfin.org/",
+    "type": "anime",
+    "name": "Jellyfin"
+  },
+  {
+    "domain": "https://jkanime.net",
+    "type": "anime",
+    "name": "Jkanime"
+  },
+  {
+    "domain": "https://kaguya.app",
+    "type": "anime",
+    "name": "Kaguya"
+  },
+  {
+    "domain": "https://kickassanime.am",
+    "type": "anime",
+    "name": "KickAssAnime"
+  },
+  {
+    "domain": "https://komga.org",
+    "type": "manga",
+    "name": "Komga"
+  },
+  {
+    "domain": "https://latanime.org",
+    "type": "anime",
+    "name": "Latanime"
+  },
+  {
+    "domain": "https://lhtranslation.net",
+    "type": "manga",
+    "name": "LHTranslation"
+  },
+  {
+    "domain": "https://lscomic.com",
+    "type": "manga",
+    "name": "LeviatanScans"
+  },
+  {
+    "domain": "https://luciferdonghua.in",
+    "type": "anime",
+    "name": "Lucifer Donghua"
+  },
+  {
+    "domain": "https://luminous-scans.com",
+    "type": "manga",
+    "name": "LuminousScans"
+  },
+  {
+    "domain": "https://lynxscans.com",
+    "type": "manga",
+    "name": "LynxScans"
+  },
+  {
+    "domain": "https://manga.bilibili.com",
+    "type": "manga",
+    "name": "BilibiliComics"
+  },
+  {
+    "domain": "https://manga4life.com",
+    "type": "manga",
+    "name": "manga4life"
+  },
+  {
+    "domain": "https://mangabuddy.com",
+    "type": "manga",
+    "name": "MangaBuddy"
+  },
+  {
+    "domain": "https://mangafire.to",
+    "type": "manga",
+    "name": "MangaFire"
+  },
+  {
+    "domain": "https://mangahub.io",
+    "type": "manga",
+    "name": "MangaHub"
+  },
+  {
+    "domain": "https://mangajar.pro",
+    "type": "manga",
+    "name": "MangaJar"
+  },
+  {
+    "domain": "https://mangalib.me",
+    "type": "manga",
+    "name": "MangaLib"
+  },
+  {
+    "domain": "https://mangalivre.net",
+    "type": "manga",
+    "name": "Mangá Livre"
+  },
+  {
+    "domain": "https://manganato.gg",
+    "type": "manga",
+    "name": "MangaNato"
   },
   {
     "domain": "https://MangaPark.to",
     "type": "manga",
     "name": "MangaPark"
+  },
+  {
+    "domain": "https://mangaplus.shueisha.co.jp",
+    "type": "manga",
+    "name": "MangaPlus"
+  },
+  {
+    "domain": "https://mangareader.to",
+    "type": "manga",
+    "name": "MangaReader"
+  },
+  {
+    "domain": "https://mangas-origines.fr/",
+    "type": "manga",
+    "name": "MangasOrigines"
+  },
+  {
+    "domain": "https://mangasee123.com",
+    "type": "manga",
+    "name": "MangaSee"
+  },
+  {
+    "domain": "https://mangasushi.net",
+    "type": "manga",
+    "name": "MangaSushi"
+  },
+  {
+    "domain": "https://mangatx.com",
+    "type": "manga",
+    "name": "mangatx"
+  },
+  {
+    "domain": "https://mangtto.com",
+    "type": "manga",
+    "name": "Mangitto"
+  },
+  {
+    "domain": "https://manhuafast.com",
+    "type": "manga",
+    "name": "manhuafast"
+  },
+  {
+    "domain": "https://manhuaplus.com",
+    "type": "manga",
+    "name": "ManhuaPlus"
+  },
+  {
+    "domain": "https://manhuaus.com",
+    "type": "manga",
+    "name": "ManhuaUS"
+  },
+  {
+    "domain": "https://moeclip.com",
+    "type": "anime",
+    "name": "moeclip"
+  },
+  {
+    "domain": "https://monoschinos2.com",
+    "type": "anime",
+    "name": "MonosChinos"
+  },
+  {
+    "domain": "https://myanimelist.net",
+    "type": "anime",
+    "name": "MyAnimeList"
+  },
+  {
+    "domain": "https://neoxscans.com/",
+    "type": "manga",
+    "name": "NeoxScans"
+  },
+  {
+    "domain": "https://ogladajanime.pl",
+    "type": "anime",
+    "name": "OgladajAnime"
+  },
+  {
+    "domain": "https://okanime.tv",
+    "type": "anime",
+    "name": "Okanime"
+  },
+  {
+    "domain": "https://otakufr.cc",
+    "type": "anime",
+    "name": "OtakuFR"
+  },
+  {
+    "domain": "https://projectsuki.com",
+    "type": "manga",
+    "name": "projectsuki"
+  },
+  {
+    "domain": "https://proxer.me",
+    "type": "anime",
+    "name": "Proxer"
+  },
+  {
+    "domain": "https://q1n.net",
+    "type": "anime",
+    "name": "Q1N"
+  },
+  {
+    "domain": "https://ranobelib.me",
+    "type": "manga",
+    "name": "RanobeLib"
+  },
+  {
+    "domain": "https://rawkuma.com",
+    "type": "manga",
+    "name": "Rawkuma"
+  },
+  {
+    "domain": "https://reader.deathtollscans.net",
+    "type": "manga",
+    "name": "DeathTollScans"
+  },
+  {
+    "domain": "https://readm.today",
+    "type": "manga",
+    "name": "Readm"
+  },
+  {
+    "domain": "https://readmanhua.net",
+    "type": "manga",
+    "name": "ReadManhua"
+  },
+  {
+    "domain": "https://reaperscans.com",
+    "type": "manga",
+    "name": "ReaperScans"
+  },
+  {
+    "domain": "https://roliascan.com",
+    "type": "manga",
+    "name": "RoliaScan"
+  },
+  {
+    "domain": "https://scyllacomics.xyz",
+    "type": "manga",
+    "name": "ScyllaScans"
+  },
+  {
+    "domain": "https://serimanga.com",
+    "type": "manga",
+    "name": "serimanga"
+  },
+  {
+    "domain": "https://shinden.pl",
+    "type": "anime",
+    "name": "Shinden"
+  },
+  {
+    "domain": "https://smotret-anime.org",
+    "type": "anime",
+    "name": "Anime365"
+  },
+  {
+    "domain": "https://sovetromantica.com",
+    "type": "anime",
+    "name": "SovetRomantica"
+  },
+  {
+    "domain": "https://suwayomi-webui-preview.github.io/",
+    "type": "manga",
+    "name": "Suwayomi"
+  },
+  {
+    "domain": "https://taiyo.moe",
+    "type": "manga",
+    "name": "Taiyo"
+  },
+  {
+    "domain": "https://templescan.net",
+    "type": "manga",
+    "name": "TempleScan"
+  },
+  {
+    "domain": "https://tioanime.com",
+    "type": "anime",
+    "name": "tioanime"
+  },
+  {
+    "domain": "https://toonily.com",
+    "type": "manga",
+    "name": "Toonily"
+  },
+  {
+    "domain": "https://tritinia.com",
+    "type": "manga",
+    "name": "TritiniaScans"
+  },
+  {
+    "domain": "https://voiranime.com",
+    "type": "anime",
+    "name": "Voiranime"
+  },
+  {
+    "domain": "https://vortexscans.org",
+    "type": "manga",
+    "name": "VortexScans"
+  },
+  {
+    "domain": "https://vvww.toonanime.cc",
+    "type": "anime",
+    "name": "ToonAnime"
+  },
+  {
+    "domain": "https://weebcentral.com",
+    "type": "manga",
+    "name": "WeebCentral"
+  },
+  {
+    "domain": "https://witanime.pics",
+    "type": "anime",
+    "name": "WitAnime"
+  },
+  {
+    "domain": "https://wuxiaworld.site",
+    "type": "manga",
+    "name": "WuxiaWorld"
+  },
+  {
+    "domain": "https://www.adkami.com/",
+    "type": "anime",
+    "name": "ADKami"
+  },
+  {
+    "domain": "https://www.animeid.tv",
+    "type": "anime",
+    "name": "AnimeId"
+  },
+  {
+    "domain": "https://www.animelon.com",
+    "type": "anime",
+    "name": "Animelon"
+  },
+  {
+    "domain": "https://www.animeonegai.com",
+    "type": "anime",
+    "name": "AnimeOnegai"
+  },
+  {
+    "domain": "https://www.animetoast.cc",
+    "type": "anime",
+    "name": "Animetoast"
+  },
+  {
+    "domain": "https://www.animeworld.tv",
+    "type": "anime",
+    "name": "Animeworld"
+  },
+  {
+    "domain": "https://www.animezone.pl",
+    "type": "anime",
+    "name": "AnimeZone"
+  },
+  {
+    "domain": "https://www.bluesolo.org",
+    "type": "manga",
+    "name": "BlueSolo"
+  },
+  {
+    "domain": "https://www.crunchyroll.com",
+    "type": "anime",
+    "name": "Crunchyroll"
+  },
+  {
+    "domain": "https://www.hidive.com",
+    "type": "anime",
+    "name": "Hidive"
+  },
+  {
+    "domain": "https://www.hulu.com",
+    "type": "anime",
+    "name": "Hulu"
+  },
+  {
+    "domain": "https://www.japscan.ws",
+    "type": "manga",
+    "name": "JapScan"
+  },
+  {
+    "domain": "https://www.mangadenizi.net",
+    "type": "manga",
+    "name": "mangadenizi"
+  },
+  {
+    "domain": "https://www.mangadex.org",
+    "type": "manga",
+    "name": "Mangadex"
+  },
+  {
+    "domain": "https://www.mangaread.org",
+    "type": "manga",
+    "name": "MangaRead"
+  },
+  {
+    "domain": "https://www.miruro.to",
+    "type": "anime",
+    "name": "Miruro"
+  },
+  {
+    "domain": "https://www.netflix.com",
+    "type": "anime",
+    "name": "Netflix"
+  },
+  {
+    "domain": "https://www.otakustv.com",
+    "type": "anime",
+    "name": "Otakustv"
+  },
+  {
+    "domain": "https://www.tranimeizle.net/",
+    "type": "anime",
+    "name": "TRanimeizle"
+  },
+  {
+    "domain": "https://www.turkanime.co",
+    "type": "anime",
+    "name": "TurkAnime"
+  },
+  {
+    "domain": "https://www.viz.com",
+    "type": "manga",
+    "name": "VIZ"
+  },
+  {
+    "domain": "https://zeroscans.com",
+    "type": "manga",
+    "name": "ZeroScans"
+  },
+  {
+    "domain": "https://zonatmo.com",
+    "type": "manga",
+    "name": "tmofans"
   }
 ]

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -828,8 +828,16 @@ module.exports = {
   anizmplayer: {
     match: ['*://*.anizmplayer.com/*'],
   },
+  // Animecix
+  tauvideo: {
+    match: ['*://tau-video.xyz/*', '*://*.tau-video.xyz/*'],
+  },
   // aniworld
   loadx: {
      match: ['*://loadx.ws/*'],
+  },
+  // Diziwatch
+  pichive: {
+    match: ['*://*.pichive.online/*'],
   }
 };


### PR DESCRIPTION
With this change, iframe-based video players on Diziwatch and Animecix sites have been updated to be correctly detected and send time information to MALSync. 
## Changes Made 
### 1. Added iframe support to the Player.ts file 
- Created a message listener for iframe-based players 
- Captured time information coming from the iframe, enabling MALSync to use this information 
- Created a Map structure for the iframe player status 
### 2. Updated the Diziwatch main.ts file 
- Defined the iframe[src*=“pichive.online”] selector 
- Added an advanced control mechanism to detect the iframe player 
- Updated the addPlayerMessageListener function to listen for messages from the iframe 
- postMessage was used to send the iframe player's time information to the parent window 
- state variables were added to check if the iframe player is ready 
### 3. The iframe domain for Diziwatch was added to the PlayerUrls.js file 
- The ‘*://*.pichive.online/*’ domain was defined under the pichive object 
### 4. Similar changes were applied for Animecix 
- The iframe[src*=“tau-video.xyz”] selector was defined 
- An advanced control mechanism was added to detect the iframe player 
- The addPlayerMessageListener function was updated to listen for messages from the iframe 
- postMessage was used to send the iframe player's time information to the parent window 
- state variables were added to check if the iframe player is ready With these changes, the Diziwatch and Animecix implementations will now correctly detect iframe-based players and be able to send time information to MALSync. This will ensure the scrobbler works correctly.