### PR TITLE
fix popup width

### DIFF
--- a/src/_minimal/components/dynamic-font.vue
+++ b/src/_minimal/components/dynamic-font.vue
@@ -29,7 +29,9 @@ const length = computed(() => props.text.length);
 const getCharWidth = (fontSize: number) => fontSize * 0.55;
 
 const size = computed(() => {
-  const fieldWidth = target.value ? target.value.clientWidth : rootWindow.innerWidth - 310;
+  const fieldWidth = target.value
+    ? target.value.clientWidth
+    : Math.min(rootWindow.innerWidth, rootWindow.screen.width) - 310;
 
   let found = props.sizes.find(fontSize => {
     const charWidth = getCharWidth(fontSize);

--- a/src/_minimal/install.html
+++ b/src/_minimal/install.html
@@ -3,7 +3,7 @@
   <head>
     <title>MAL-Sync</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=500">
+    <meta name="viewport" content="width=550">
     <link rel="stylesheet" type="text/css" href="vendor/materialFont.css">
     <link rel="stylesheet" type="text/css" href="vendor/montserrat.css">
   </head>

--- a/src/_minimal/minimalApp.vue
+++ b/src/_minimal/minimalApp.vue
@@ -35,7 +35,7 @@ const rootHtml = inject('rootHtml') as HTMLElement;
 const rootBody = inject('rootBody') as HTMLElement;
 
 function setBreakpoint() {
-  if (rootWindow.innerWidth < 900) {
+  if (Math.min(rootWindow.innerWidth, rootWindow.screen.width) < 900) {
     breakpoint.value = 'mobile';
   } else {
     breakpoint.value = 'desktop';
@@ -50,11 +50,9 @@ function isExtension() {
 onMounted(() => {
   rootWindow.addEventListener('resize', setBreakpoint);
   nextTick(() => {
-    if (
-      ['popup', 'settings'].includes(rootHtml.getAttribute('mode')!) &&
-      rootWindow.innerWidth !== 550
-    ) {
-      rootHtml.style.minWidth = `${rootWindow.innerWidth}px`;
+    const width = Math.min(rootWindow.innerWidth, rootWindow.screen.width);
+    if (['popup', 'settings'].includes(rootHtml.getAttribute('mode')!) && width !== 550) {
+      rootHtml.style.minWidth = `${width}px`;
       // rootHtml.style.maxWidth = `${rootWindow.innerWidth}px`;
       rootHtml.style.width = 'auto';
       rootBody.style.width = 'auto';

--- a/src/_minimal/popup.html
+++ b/src/_minimal/popup.html
@@ -3,7 +3,7 @@
   <head>
     <title>MAL-Sync</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=500">
+    <meta name="viewport" content="width=550">
     <link rel="stylesheet" type="text/css" href="vendor/materialFont.css">
     <link rel="stylesheet" type="text/css" href="vendor/montserrat.css">
     <style type="text/css">

--- a/src/_minimal/settings.html
+++ b/src/_minimal/settings.html
@@ -3,7 +3,7 @@
   <head>
     <title>MAL-Sync</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=500">
+    <meta name="viewport" content="width=550">
     <link rel="stylesheet" type="text/css" href="vendor/materialFont.css">
     <link rel="stylesheet" type="text/css" href="vendor/montserrat.css">
     <style type="text/css">

--- a/src/_minimal/window.html
+++ b/src/_minimal/window.html
@@ -3,7 +3,7 @@
   <head>
     <title>MAL-Sync</title>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=500">
+    <meta name="viewport" content="width=550">
     <link rel="stylesheet" type="text/css" href="vendor/materialFont.css">
     <link rel="stylesheet" type="text/css" href="vendor/montserrat.css">
   </head>


### PR DESCRIPTION
Fixes the popup window width on Orion (iOS), Firefox (Android), and Edge (Android).

<details>
  <summary>Orion before:</summary>
  <img width="603" height="1311" alt="IMG_1018" src="https://github.com/user-attachments/assets/6c1dc929-95ae-4da6-96a0-4b0aaf1adfb8" />
</details>

<details>
  <summary>Orion after:</summary>
  <img width="603" height="1311" alt="IMG_1017" src="https://github.com/user-attachments/assets/e78cbe48-f5e5-4571-8197-59480036c008" />
</details>

<details>
  <summary>Firefox before:</summary>
  <img width="806" height="1795" alt="Screenshot_20250928-114249" src="https://github.com/user-attachments/assets/c1f7c613-377d-4886-81ab-2a8783e2fcfb" />
</details>

<details>
  <summary>Firefox after:</summary>
  <img width="806" height="1795" alt="Screenshot_20250928-114920" src="https://github.com/user-attachments/assets/90c2b0fe-6c90-42dd-9c9a-a3697c8860fe" />
</details>

<details>
  <summary>Edge before:</summary>
  <img width="806" height="1795" alt="Screenshot_20250928-114001" src="https://github.com/user-attachments/assets/f5350480-5a27-4925-a817-d320195b837e" />
</details>

<details>
  <summary>Edge after:</summary>
  <img width="806" height="1795" alt="Screenshot_20250928-115845" src="https://github.com/user-attachments/assets/aebd6957-7f42-4760-a944-e52c9e78b884" />
</details>