### PR TITLE
Fix Discord RPC timing and use provider runtimes

### DIFF
--- a/src/_provider/AniList/single.ts
+++ b/src/_provider/AniList/single.ts
@@ -146,6 +146,14 @@ export class Single extends SingleAbstract {
     return helper.imgCheck(this.animeInfo.coverImage.large);
   }
 
+  public override getEpisodeRuntimeSeconds(): number | null {
+    const duration = this.animeInfo?.duration;
+    if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
+      return duration * 60;
+    }
+    return null;
+  }
+
   _getRating() {
     return Promise.resolve(this.animeInfo.averageScore);
   }
@@ -165,6 +173,7 @@ export class Single extends SingleAbstract {
         idMal
         siteUrl
         episodes
+        duration
         chapters
         volumes
         averageScore

--- a/src/_provider/MyAnimeList_api/single.ts
+++ b/src/_provider/MyAnimeList_api/single.ts
@@ -215,6 +215,14 @@ export class Single extends SingleAbstract {
     return this.animeInfo.main_picture?.medium ?? '';
   }
 
+  public override getEpisodeRuntimeSeconds(): number | null {
+    const duration = this.animeInfo?.average_episode_duration;
+    if (typeof duration === 'number' && Number.isFinite(duration) && duration > 0) {
+      return duration;
+    }
+    return null;
+  }
+
   _getRating() {
     return Promise.resolve(this.animeInfo.mean);
   }
@@ -227,6 +235,7 @@ export class Single extends SingleAbstract {
         'my_list_status{tags,is_rewatching,is_rereading,num_times_rewatched,num_times_reread,start_date,finish_date}',
         'num_episodes',
         'mean',
+        'average_episode_duration',
         // Manga
         'num_chapters',
         'num_volumes',

--- a/src/_provider/Simkl/single.ts
+++ b/src/_provider/Simkl/single.ts
@@ -174,6 +174,14 @@ export class Single extends SingleAbstract {
     return `https://simkl.in/posters/${this.animeInfo.show.poster}_ca.jpg`;
   }
 
+  public override getEpisodeRuntimeSeconds(): number | null {
+    const runtime = this.animeInfo?.show?.runtime;
+    if (typeof runtime === 'number' && Number.isFinite(runtime) && runtime > 0) {
+      return runtime * 60;
+    }
+    return null;
+  }
+
   async _getRating() {
     try {
       const el = await this.call('https://api.simkl.com/ratings', { simkl: this.ids.simkl }, true);

--- a/src/_provider/singleAbstract.ts
+++ b/src/_provider/singleAbstract.ts
@@ -626,6 +626,15 @@ export abstract class SingleAbstract {
     return null;
   }
 
+  /**
+   * Average runtime of one episode in seconds, if the provider exposes it.
+   * Allows consumers (e.g. Discord Rich Presence) to fall back to metadata
+   * when the detected video element reports inaccurate durations.
+   */
+  public getEpisodeRuntimeSeconds(): number | null {
+    return null;
+  }
+
   public increaseRewatchCount(): void {
     //  do nothing
   }


### PR DESCRIPTION
# Fix Discord RPC Timing Issues and Improve Metadata Integration

## Description
This PR addresses timing inaccuracies in Discord Rich Presence and enhances the reliability of time reporting by integrating provider metadata as a fallback mechanism.

### Key Changes

#### 1. Timing Fix - Seconds Instead of Milliseconds
Changed Discord RPC timing calculations from milliseconds to seconds to align with Discord's API expectations:
- Updated browsingtime initialization and usage to use seconds
- Modified timestamp calculations throughout the presence logic to use second-based timestamps

#### 2. Provider Runtime Metadata Integration
Added getEpisodeRuntimeSeconds() method to provider classes to expose episode runtime metadata:
- **AniList**: Uses duration field (converted from minutes to seconds)
- **MyAnimeList**: Uses `average_episode_duration` field (already in seconds)
- **Simkl**: Uses `runtime` field (converted from minutes to seconds)

#### 3. Enhanced Duration Logic
Implemented smarter duration handling in Discord presence:
- Uses provider metadata as fallback when detected video duration is unavailable
- Compares detected vs metadata durations and uses metadata when discrepancy exceeds 10%
- Prioritizes the most reliable duration source for accurate time remaining calculations
- Added validation to ensure duration values are finite numbers greater than zero

### Benefits
- More accurate Discord Rich Presence timing
- Reduced timing drift when video players report incorrect durations
- Better user experience with consistent time remaining calculations
- Fallback mechanism ensures presence works even when video detection fails

### Technical Details
The changes modify how Discord timestamps are calculated in syncPage.ts by:
1. Using `Math.floor(Date.now() / 1000)` for second-based timestamps
2. Implementing a dual-source duration system that prioritizes accuracy
3. Adding proper validation for all duration values

Provider implementations now expose runtime metadata through the standardized getEpisodeRuntimeSeconds() interface, allowing consumers like Discord RPC to access this information when needed.

Fixes timing issues reported in Discord Rich Presence where users experienced incorrect time remaining values and inconsistent status updates.