### PR TITLE
temporary fix for Utoon, ResetScans, TrinitiaScans for webstore extension version

### DIFF
--- a/src/pages-chibi/implementations/ResetScans/main.ts
+++ b/src/pages-chibi/implementations/ResetScans/main.ts
@@ -113,7 +113,7 @@ export const ResetScans: PageInterface = {
         .if(
           $c.url().urlPart(5).boolean().run(),
           $c.detectChanges($c.url().urlPart(5).run(), $c.trigger().run()).run(),
-          $c.detectURLChanges($c.trigger().run()).run(),
+          $c.run(),
         )
         .domReady()
         .trigger()

--- a/src/pages-chibi/implementations/TritiniaScans/main.ts
+++ b/src/pages-chibi/implementations/TritiniaScans/main.ts
@@ -114,7 +114,7 @@ export const TritiniaScans: PageInterface = {
         .if(
           $c.url().urlPart(5).boolean().run(),
           $c.detectChanges($c.url().urlPart(5).run(), $c.trigger().run()).run(),
-          $c.detectURLChanges($c.trigger().run()).run(),
+          $c.run(),
         )
         .domReady()
         .trigger()

--- a/src/pages-chibi/implementations/Utoon/main.ts
+++ b/src/pages-chibi/implementations/Utoon/main.ts
@@ -120,7 +120,7 @@ export const Utoon: PageInterface = {
         .if(
           $c.url().urlPart(5).boolean().run(),
           $c.detectChanges($c.url().urlPart(5).run(), $c.trigger().run()).run(),
-          $c.detectURLChanges($c.trigger().run()).run(),
+          $c.run(),
         )
         .domReady()
         .trigger()


### PR DESCRIPTION
Since the .detectChange fix #3257 doesn't apply yet on webstore extension, it make malsync broken on those three website.
so this is only for temporary fix for it.

After malsync webstore version update, probably can revert the code back