### PR TITLE
add search for Philia Scans

### DIFF
--- a/src/pages-chibi/implementations/PhiliaScans/main.ts
+++ b/src/pages-chibi/implementations/PhiliaScans/main.ts
@@ -8,6 +8,7 @@ export const PhiliaScans: PageInterface = {
   urls: {
     match: ['*://philiascans.org/*'],
   },
+  search: 'https://philiascans.org/?post_type=wp-manga&s={searchtermPlus}',
   sync: {
     isSyncPage($c) {
       return $c


### PR DESCRIPTION
Apparently, the `post_type=wp-manga` parameter is required for the search to work properly, but the search function on the site doesn't include it, which breaks the search function.