### PR TITLE
fix new OverviewUrl on Kagane

### DIFF
--- a/src/pages-chibi/implementations/Kagane/main.ts
+++ b/src/pages-chibi/implementations/Kagane/main.ts
@@ -29,7 +29,7 @@ export const Kagane: PageInterface = {
     },
     getOverviewUrl($c) {
       return $c
-        .querySelector('a[href^="/series/"]')
+        .querySelector('a[href^="/series/"]:not([href*="/reader/"])')
         .getAttribute('href')
         .ifNotReturn()
         .urlAbsolute()


### PR DESCRIPTION
I just notice, just a bit change in element 'a' when finding overviewurl because it gave previous chapter