### PR TITLE
Armageddon add theme color #fc7500

### DIFF
--- a/src/pages-chibi/implementations/Armageddon/main.ts
+++ b/src/pages-chibi/implementations/Armageddon/main.ts
@@ -99,7 +99,14 @@ export const Armageddon: PageInterface = {
   },
   lifecycle: {
     setup($c) {
-      return $c.addStyle(require('./style.less?raw').toString()).run();
+      return $c
+        .addCssVariable(
+          '--theme-color',
+          $c.querySelector('meta[name="theme-color"]').getAttribute('content').string().run(),
+          '#002e7459',
+        )
+        .addStyle(require('./style.less?raw').toString())
+        .run();
     },
     ready($c) {
       return $c.domReady().detectURLChanges($c.trigger().run()).trigger().run();

--- a/src/pages-chibi/implementations/Armageddon/style.less
+++ b/src/pages-chibi/implementations/Armageddon/style.less
@@ -4,22 +4,6 @@
 @boxBackground: var(--box-background);
 @highlightStyle: 1;
 
-:root {
-  --theme-color: #002e7459;
-
-  &:has(meta[name='theme-color'][content='#ea3364']) {
-    --theme-color: #ea3364;
-  }
-
-  &:has(meta[name='theme-color'][content='#3367d6']) {
-    --theme-color: #3367d6;
-  }
-
-  &:has(meta[name='theme-color'][content='#fc7500']) {
-    --theme-color: #fc7500;
-  }
-}
-
 #malp {
   --box-background: #343434;
 


### PR DESCRIPTION
Ideally, we should be able to set the color dynamically by the meta element `meta[name='theme-color']`, but this is just a quick fix.