### PR TITLE
fix malsync-rel-link from being able to be copied in anilist

### DIFF
--- a/src/anilist/anilistClass.ts
+++ b/src/anilist/anilistClass.ts
@@ -248,7 +248,11 @@ export class AnilistClass {
     await malObj.fillRelations();
 
     $('.malsync-rel-link').remove();
-    $('h1').first().append(j.html('<div class="malsync-rel-link" style="float: right; user-select: none;"></div>'));
+    $('h1')
+      .first()
+      .append(
+        j.html('<div class="malsync-rel-link" style="float: right; user-select: none;"></div>'),
+      );
 
     malObj.getPageRelations().forEach(page => {
       $('.malsync-rel-link').append(


### PR DESCRIPTION
add `user-select: none` to anilist in malsync-rel-link

#3368 #3369