### PR TITLE
fix malsync-rel-link from being able to be copied in kitsu

### DIFF
--- a/src/kitsu/kitsuClass.ts
+++ b/src/kitsu/kitsuClass.ts
@@ -311,7 +311,7 @@ export class KitsuClass {
       .first()
       .append(
         j.html(
-          '<div class="malsync-rel-link" style="display: inline-block; margin: 0 5px; vertical-align: bottom;"></div>',
+          '<div class="malsync-rel-link" style="display: inline-block; margin: 0 5px; vertical-align: bottom; user-select: none;"></div>',
         ),
       );
 


### PR DESCRIPTION
add `user-select: none` to kitsu in malsync-rel-link

#3368 #3369