### PR TITLE
fix #3373 - "close" button getting hidden on small devices

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,20 +3,9 @@
   // https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint#optional-but-recommended-setup
   "css.validate": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.rulers": [
-    120
-  ],
-  "eslint.validate": [
-    "javascript",
-    "typescript",
-    "vue"
-  ],
-  "stylelint.validate": [
-    "css",
-    "scss",
-    "vue",
-    "less"
-  ],
+  "editor.rulers": [120],
+  "eslint.validate": ["javascript", "typescript", "vue"],
+  "stylelint.validate": ["css", "scss", "vue", "less"],
   "less.validate": false,
   "scss.validate": false,
   "vetur.validation.template": false,
@@ -24,7 +13,4 @@
     "turkanime",
     "tranimeizle"
   ],
-  "[javascript]": {
-    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint"
-  },
 }


### PR DESCRIPTION
Makes it so close button never gets hidden based on screen height, in correction menu popup.