### PR TITLE
Add sidebar support for Opera

### DIFF
--- a/webpackConfig/webextension.assets.js
+++ b/webpackConfig/webextension.assets.js
@@ -139,7 +139,7 @@ const generateManifest = () => {
       },
     },
     sidebar_action: {
-      default_panel: "window.html",
+      default_panel: 'window.html',
       default_icon: {
         '16': 'icons/icon16.png',
         '32': 'icons/icon32.png',


### PR DESCRIPTION
Adds sidebar support for Opera and Opera GX.

<details>
  <summary>Image</summary>
  <img src="https://github.com/user-attachments/assets/708d3b0c-86cc-4777-af05-4e3fc6b9f0b8" />
</details>