### PR TITLE
change ui placement on mangaplus when on mobile/small screen

### DIFF
--- a/src/pages-chibi/implementations/MangaPlus/main.ts
+++ b/src/pages-chibi/implementations/MangaPlus/main.ts
@@ -83,8 +83,8 @@ export const MangaPlus: PageInterface = {
     },
     uiInjection($c) {
       return $c
-        .querySelector('h6[class*="TitleDetailHeader-module_overviewTitle"]')
-        .uiBefore()
+        .querySelector('[class*="TitleDetailHeader-module_overviewTitleWrapper"]')
+        .uiAfter()
         .run();
     },
   },


### PR DESCRIPTION
<img width="459" height="448" alt="from this" src="https://github.com/user-attachments/assets/14afab87-13f2-4d2b-83c7-f6c8a7af838c" />

to this
<img width="455" height="519" alt="to this" src="https://github.com/user-attachments/assets/ae6923c0-e739-47b7-a076-1e9b4124ef04" />
