### PR TITLE
Add new match URL pattern for aniwatchtv.to

### DIFF
--- a/src/pages/Zoro/meta.json
+++ b/src/pages/Zoro/meta.json
@@ -2,6 +2,7 @@
   "search": "https://hianime.to/search?keyword={searchtermPlus}",
   "urls": {
     "match": [
+      "*://aniwatchtv.to/*",
       "*://aniwatch.to/*",
       "*://aniwatch.nz/*",
       "*://aniwatch.se/*",


### PR DESCRIPTION
Added the domain aniwatchtv.to to Zoro/Hianime since they use the same url mappings