### PR TITLE
Make text in anime title easily selectable

### DIFF
--- a/src/_minimal/views/overview.vue
+++ b/src/_minimal/views/overview.vue
@@ -323,6 +323,7 @@ const totalLoading = computed(() => {
     .header-title {
       position: relative;
       width: 100%;
+      cursor: text;
 
       .header-synonyms {
         display: none;


### PR DESCRIPTION
The title (in media-link) that can be clicked to redirect to provider, is hard to select directly, because it's draggable because of the a tag, so I added `draggable=false` to it, so you can easily select the text.
<br />
![Recording 2025-12-16 at 13 47 31](https://github.com/user-attachments/assets/8dc7a1bc-f617-4b4f-a777-95ede21ab139)