### PR TITLE
Update vidmoly domain

### DIFF
--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -92,6 +92,7 @@
       "*://*.md3b0j6hj.com/e/*",
       "*://animevost.org/frame5.php?play=*",
       "*://vidmoly.net/*",
+      "*://vidmoly.biz/*",
       "*://jilliandescribecompany.com/e/*",
       "*://lukesitturn.com/e/*",
       "*://mikaylaarealike.com/e/*",

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -484,6 +484,7 @@ module.exports = {
       '*://vidmoly.me/*',
       '*://vidmoly.to/*',
       '*://vidmoly.net/*',
+      '*://vidmoly.biz/*',
       // auto-vidmoly-replace-dont-remove
     ],
   },


### PR DESCRIPTION
Required for default player on latest voiranime episodes (e.g. https://v6.voiranime.com/anime/tis-time-for-torture-princess-2/tis-time-for-torture-princess-2-03-vostfr/)

I don't know why it has not correctly been detected by the autoUrls script…