### PR TITLE
Suppress popup for contentEditable elements

### DIFF
--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -208,7 +208,7 @@ export function shortcutListener(callback) {
         if (checkShortcut(option)) {
           if (
             e.target instanceof Node &&
-            (/textarea|input|select/i.test(e.target.nodeName) || (e.target instanceof Element && e.target.shadowRoot))
+            (/textarea|input|select/i.test(e.target.nodeName) || (e.target instanceof Element && (e.target.shadowRoot || e.target.isContentEditable)))
           ) {
             con.info('Input field. Shortcut suppressed.');
           } else {


### PR DESCRIPTION
Update shortcutListener to treat elements with isContentEditable as input fields. The event target check now includes e.target.isContentEditable (in addition to shadowRoot) so keyboard shortcuts are suppressed when the user is editing contentEditable elements, preventing accidental triggers.
Have built and tested on my personal laptop, can confirm this works.

As per discussed on Discord, the Mozilla documentation for this - https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/contenteditable
isContentEditable has existed in browsers since 2015 and supports all modern web browsers - https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable