### PR TITLE
Reduce AniList calls

### DIFF
--- a/src/_provider/AniList/list.ts
+++ b/src/_provider/AniList/list.ts
@@ -110,72 +110,65 @@ export class UserList extends ListAbstract {
       this.username = await this.getUsername();
     }
 
-    let query = `
-    query ($page: Int, $userName: String, $type: MediaType, $status: MediaListStatus, $sort: [MediaListSort] ) {
-      MediaListCollection(status: $status, type: $type, userName: $userName, sort: $sort, chunk: $page, perChunk: 500, forceSingleCompletedList: true ) {
-        hasNextChunk
-        lists { entries {
+    const fields = this.compact
+      ? 'progress media { id idMal }'
+      : `
+        status
+        startedAt {
+          year
+          month
+          day
+        }
+        completedAt {
+          year
+          month
+          day
+        }
+        repeat
+        score(format: POINT_100)
+        progress
+        progressVolumes
+        notes
+        media {
+          siteUrl
+          id
+          idMal
+          episodes
+          chapters
+          volumes
           status
-          startedAt {
-            year
-            month
-            day
+          averageScore
+          coverImage{
+            large
+            extraLarge
           }
-          completedAt {
-            year
-            month
-            day
+          bannerImage
+          title {
+            userPreferred
           }
-          repeat
-          score(format: POINT_100)
-          progress
-          progressVolumes
-          notes
-          media {
-            siteUrl
-            id
-            idMal
-            episodes
-            chapters
-            volumes
-            status
-            averageScore
-            coverImage{
-              large
-              extraLarge
-            }
-            bannerImage
-            title {
-              userPreferred
-            }
-          }}
+        }
+`;
+
+    const query = `
+    query ($page: Int, $userName: String, $type: MediaType, $status: MediaListStatus, $sort: [MediaListSort], $itemCount: Int ) {
+      MediaListCollection(status: $status, type: $type, userName: $userName, sort: $sort, chunk: $page, perChunk: $itemCount, forceSingleCompletedList: true ) {
+        hasNextChunk
+        lists { 
+          entries {
+            ${fields}
+          }
         }
       }
     }
     `;
 
-    if (this.compact) {
-      query = `
-      query ($page: Int, $userName: String, $type: MediaType, $status: MediaListStatus, $sort: [MediaListSort]) {
-        MediaListCollection(status: $status, type: $type, userName: $userName, sort: $sort, chunk: $page, perChunk: 500, forceSingleCompletedList: true) {
-          hasNextChunk
-          lists { entries {
-            progress
-            media {
-              id
-              idMal
-            }
-          }}
-        }
-      }
-      `;
-    }
     const variables = {
       page: this.offset,
       userName: this.username,
       type: this.listType.toUpperCase(),
       status: helper.statusTranslate[parseInt(this.status.toString())],
       sort: null,
+      itemCount: this.modes.frontend && !this.modes.sortAiring ? 50 : 500,
     };
 
     const order = this.getOrder(this.sort);

--- a/src/_provider/AniList/list.ts
+++ b/src/_provider/AniList/list.ts
@@ -112,11 +112,9 @@ export class UserList extends ListAbstract {
 
     let query = `
     query ($page: Int, $userName: String, $type: MediaType, $status: MediaListStatus, $sort: [MediaListSort] ) {
-      Page (page: $page, perPage: 100) {
-        pageInfo {
-          hasNextPage
-        }
-        mediaList (status: $status, type: $type, userName: $userName, sort: $sort) {
+      MediaListCollection(status: $status, type: $type, userName: $userName, sort: $sort, chunk: $page, perChunk: 500, forceSingleCompletedList: true ) {
+        hasNextChunk
+        lists { entries {
           status
           startedAt {
             year
@@ -150,7 +148,7 @@ export class UserList extends ListAbstract {
             title {
               userPreferred
             }
-          }
+          }}
         }
       }
     }
@@ -159,17 +157,15 @@ export class UserList extends ListAbstract {
     if (this.compact) {
       query = `
       query ($page: Int, $userName: String, $type: MediaType, $status: MediaListStatus, $sort: [MediaListSort]) {
-        Page (page: $page, perPage: 100) {
-          pageInfo {
-            hasNextPage
-          }
-          mediaList (status: $status, type: $type, userName: $userName, sort: $sort) {
+        MediaListCollection(status: $status, type: $type, userName: $userName, sort: $sort, chunk: $page, perChunk: 500, forceSingleCompletedList: true) {
+          hasNextChunk
+          lists { entries {
             progress
             media {
               id
               idMal
             }
-          }
+          }}
         }
       }
       `;
@@ -191,9 +187,9 @@ export class UserList extends ListAbstract {
 
     return helper.apiCall(query, variables, true).then(res => {
       con.log('res', res);
-      const data = res.data.Page.mediaList;
+      const data = res.data.MediaListCollection.lists.flatMap(list => list.entries);
       this.offset += 1;
-      if (!res.data.Page.pageInfo.hasNextPage) {
+      if (!res.data.MediaListCollection.hasNextChunk) {
         this.done = true;
       }
 


### PR DESCRIPTION
Replace `Pages` (limited to 50 entries per call) with `MediaListCollection` (up to 500 entries per call) on the GraphQL query, drastically reducing the number of calls by 90% and consequently the chance of hitting the rate limit during list sync.

Both my 1.5k+ anime and 2.5k+ manga lists went from guaranteed rate-limit after about 20 pages in half a minute-ish to successful population within a few seconds for the 4-6 pages on the sync screen.