### PR TITLE
Update search URL and modify match patterns for KickAssAnime

### DIFF
--- a/src/pages/KickAssAnime/meta.json
+++ b/src/pages/KickAssAnime/meta.json
@@ -1,18 +1,11 @@
 {
-  "search": "https://kaas.am/search?q={searchterm}",
+  "search": "https://kaa.lt/search?q={searchterm}",
   "urls": {
     "match": [
-      "*://*.kaas.am/*",
-      "*://*.kaas.ro/*",
-      "*://*.kaas.to/*",
-      "*://*.kickassanime.ro/*",
-      "*://*.kickassanime.am/*",
-      "*://*.kickassanimes.io/*",
-      "*://*.kickassanime.mx/*",
-      "*://*.kaa.mx/*",
-      "*://*.kaa.to/*",
+      "*://*.kaa.lt/*",
       "*://*.kaa.si/*",
-      "*://*.kickass-anime.ro/*",
+      "*://*.kaa.to/*",
+      "*://*.kaa.rs/*",
       "*://*.kickassanime.cx/*"
     ]
   }


### PR DESCRIPTION
Official Domain Update for KickAssAnime

Main website:
https://kaa.lt/

The previous domain is now redirecting to this new address.

✅ Currently active domains
https://kaa.lt/ — Main website
https://kaa.si/ — Fast redirect
https://kaa.to/ — Redirect to main domain
https://kaa.rs/ — Redirect to main domain

Backup domain (recommended to bookmark)
https://kickassanime.cx/

Use this only in case of outages.