### PR TITLE
fix: Update voiranime domain name

### DIFF
--- a/src/pages/Voiranime/main.ts
+++ b/src/pages/Voiranime/main.ts
@@ -2,7 +2,7 @@ import { pageInterface } from '../pageInterface';
 
 export const Voiranime: pageInterface = {
   name: 'Voiranime',
-  domain: 'https://voiranime.com',
+  domain: 'https://voiranime.tv',
   languages: ['French'],
   type: 'anime',
   isSyncPage(url) {

--- a/src/pages/Voiranime/meta.json
+++ b/src/pages/Voiranime/meta.json
@@ -1,6 +1,6 @@
 {
-  "search": "https://voiranime.com/?s={searchtermPlus}",
+  "search": "https://voiranime.tv/?s={searchtermPlus}",
   "urls": {
-    "match": ["*://*.voiranime.com/*", "*://*.voiranime.tv/*"]
+    "match": ["*://*.voiranime.tv/*", "*://*.voiranime.tv/*"]
   }
 }

--- a/src/pages/Voiranime/tests.json
+++ b/src/pages/Voiranime/tests.json
@@ -1,33 +1,33 @@
 {
   "title": "Voiranime",
-  "url": "http://voiranime.com",
+  "url": "http://voiranime.tv",
   "testCases": [
     {
-      "url": "https://v6.voiranime.com/anime/no-game-no-life/no-game-no-life-06-vostfr/",
+      "url": "https://voiranime.tv/anime/no-game-no-life/no-game-no-life-06-vostfr/",
       "expected": {
         "sync": true,
         "title": "No Game No Life",
         "identifier": "no-game-no-life",
-        "overviewUrl": "https://voiranime.com/anime/no-game-no-life",
-        "nextEpUrl": "https://v6.voiranime.com/anime/no-game-no-life/no-game-no-life-07-vostfr/",
+        "overviewUrl": "https://voiranime.tv/anime/no-game-no-life",
+        "nextEpUrl": "https://voiranime.tv/anime/no-game-no-life/no-game-no-life-07-vostfr/",
         "episode": 6,
         "uiSelector": false
       }
     },
     {
-      "url": "https://v6.voiranime.com/anime/boku-no-hero-academia-2/boku-no-hero-academia-my-hero-academia-saison-2-04-vostfr/",
+      "url": "https://voiranime.tv/anime/boku-no-hero-academia-2/boku-no-hero-academia-my-hero-academia-saison-2-04-vostfr/",
       "expected": {
         "sync": true,
         "title": "Boku no Hero Academia 2",
         "identifier": "boku-no-hero-academia-2",
-        "overviewUrl": "https://voiranime.com/anime/boku-no-hero-academia-2",
-        "nextEpUrl": "https://v6.voiranime.com/anime/boku-no-hero-academia-2/boku-no-hero-academia-my-hero-academia-saison-2-05-vostfr/",
+        "overviewUrl": "https://voiranime.tv/anime/boku-no-hero-academia-2",
+        "nextEpUrl": "https://voiranime.tv/anime/boku-no-hero-academia-2/boku-no-hero-academia-my-hero-academia-saison-2-05-vostfr/",
         "episode": 4,
         "uiSelector": false
       }
     },
     {
-      "url": "https://v6.voiranime.com/anime/no-game-no-life/",
+      "url": "https://voiranime.tv/anime/no-game-no-life/",
       "expected": {
         "sync": false,
         "title": "No Game No Life",
@@ -36,28 +36,28 @@
       }
     },
     {
-      "url": "https://v6.voiranime.com/anime/kujibiki-unbalance/kujibiki-unbalance-oav2-vostfr/",
+      "url": "https://voiranime.tv/anime/kujibiki-unbalance/kujibiki-unbalance-oav2-vostfr/",
       "expected": {
         "sync": true,
         "title": "Kujibiki Unbalance",
         "identifier": "kujibiki-unbalance",
-        "overviewUrl": "https://voiranime.com/anime/kujibiki-unbalance",
-        "nextEpUrl": "https://v6.voiranime.com/anime/kujibiki-unbalance/kujibiki-unbalance-oav3-vostfr/",
+        "overviewUrl": "https://voiranime.tv/anime/kujibiki-unbalance",
+        "nextEpUrl": "https://voiranime.tv/anime/kujibiki-unbalance/kujibiki-unbalance-oav3-vostfr/",
         "episode": 2,
         "uiSelector": false
       }
     },
     {
-      "url": "https://v6.voiranime.com/anime/kujibiki-unbalance/",
+      "url": "https://voiranime.tv/anime/kujibiki-unbalance/",
       "expected": {
         "sync": false,
         "title": "Kujibiki Unbalance",
         "identifier": "kujibiki-unbalance",
         "uiSelector": true,
         "epList": {
-          "3": "https://v6.voiranime.com/anime/kujibiki-unbalance/kujibiki-unbalance-oav3-vostfr/"
+          "3": "https://voiranime.tv/anime/kujibiki-unbalance/kujibiki-unbalance-oav3-vostfr/"
         }
       }
-    },
+    }
   ]
 }


### PR DESCRIPTION
Replace all occurrences of voiranime.com and v6.voiranime.com with the new domain name voiranime.tv.
This includes updates to main implementation, metadata, and test cases.