### PR TITLE
add mangabaka to providerurlutility

### DIFF
--- a/src/chibiScript/utilities/internalUtilities.ts
+++ b/src/chibiScript/utilities/internalUtilities.ts
@@ -12,10 +12,10 @@ export default {
         | 'anilistUrl'
         | 'kitsuId'
         | 'kitsuUrl'
-        | 'malId'
-        | 'malUrl'
         | 'mangabakaId'
-        | 'mangabakaUrl']?: ChibiJson<any>;
+        | 'mangabakaUrl'
+        | 'malId'
+        | 'malUrl']?: ChibiJson<any>;
     },
   ) => {
     const providerConfig = [

--- a/src/chibiScript/utilities/internalUtilities.ts
+++ b/src/chibiScript/utilities/internalUtilities.ts
@@ -13,7 +13,9 @@ export default {
         | 'kitsuId'
         | 'kitsuUrl'
         | 'malId'
-        | 'malUrl']?: ChibiJson<any>;
+        | 'malUrl'
+        | 'mangabakaId'
+        | 'mangabakaUrl']?: ChibiJson<any>;
     },
   ) => {
     const providerConfig = [
@@ -28,6 +30,12 @@ export default {
         urlKey: 'kitsuUrl',
         idKey: 'kitsuId',
         urlTemplate: 'https://kitsu.app/manga/<identifier>',
+      },
+      {
+        provider: 'MANGABAKA',
+        urlKey: 'mangabakaUrl',
+        idKey: 'mangabakaId',
+        urlTemplate: 'https://mangabaka.org/<identifier>',
       },
       {
         provider: 'MAL',

--- a/src/pages-chibi/implementations/Atsumaru/main.ts
+++ b/src/pages-chibi/implementations/Atsumaru/main.ts
@@ -124,6 +124,12 @@ export const Atsumaru: PageInterface = {
             // site using outdated .io domain
             .urlPart(4)
             .run(),
+          mangabakaId: $c
+            .querySelector('a.btn[title*="MangaBaka"]')
+            .ifNotReturn()
+            .getAttribute('href')
+            .urlPart(3)
+            .run(),
         })
         .run();
     },

--- a/src/pages-chibi/implementations/TeamShadowi/main.ts
+++ b/src/pages-chibi/implementations/TeamShadowi/main.ts
@@ -93,6 +93,11 @@ export const TeamShadowi: PageInterface = {
             .getAttribute('href')
             .ifNotReturn()
             .run(),
+          mangabakaUrl: $c
+            .querySelector('a[href*="mangabaka"]')
+            .getAttribute('href')
+            .ifNotReturn()
+            .run(),
         })
         .run();
     },

--- a/src/pages-chibi/implementations/animepahe/main.ts
+++ b/src/pages-chibi/implementations/animepahe/main.ts
@@ -16,7 +16,7 @@ export const animepahe: PageInterface = {
       '*://animepahe.si/play/*',
       '*://animepahe.si/anime/*',
       '*://animepahe.pw/play/*',
-      '*://animepahe.pw/anime/*'
+      '*://animepahe.pw/anime/*',
     ],
   },
   sync: {


### PR DESCRIPTION
i don't know whether to use mangabaka.org or mangabaka.dev since both of it works.
the thing that doesn't work currently is probably using idKey for anime since urlTemplate is for manga unless something like $c.type() is added