### PR TITLE
feat: add KamiYomu self-hosted manga reader support

### DIFF
--- a/src/pages-chibi/implementations/KamiYomu/main.ts
+++ b/src/pages-chibi/implementations/KamiYomu/main.ts
@@ -1,0 +1,217 @@
+import type { ChibiGenerator } from '../../../chibiScript/ChibiGenerator';
+import { PageInterface } from '../../pageInterface';
+
+// KamiYomu URL patterns:
+//   Reader:   /Reader/MangaReader/{libraryId}/chapter/{chapterDownloadId}?page=N
+//   Overview: /Libraries/MangaInfo/{libraryId}
+//
+// We intercept two internal API calls KamiYomu makes while loading:
+//   GET /Public/api/v1/Collection/{libraryId}
+//     → { manga: { title, links: { AniList, MyAnimeList, Kitsu } } }
+//   GET /Public/api/v1/Collection/{libraryId}/chapters/{chapterDownloadId}
+//     → { number, volume }
+
+export const KamiYomu: PageInterface = {
+  name: 'KamiYomu',
+  domain: ['http://localhost', 'http://localhost:8090'],
+  languages: ['Many'],
+  type: 'manga',
+  minimumVersion: '0.12.3',
+  urls: {
+    match: [
+      '*://*/Reader/MangaReader/*',
+      '*://*/Libraries/MangaInfo/*',
+    ],
+  },
+  features: {
+    requestProxy: true,
+    customDomains: true,
+  },
+  search: '{domain}/Libraries/Downloads?Handler=Search&Query={searchtermPlus}',
+  sync: {
+    isSyncPage($c) {
+      return $c.url().urlPart(3).equals('MangaReader').run();
+    },
+    getTitle($c) {
+      return $c
+        .getGlobalVariable('kamiyomu_title')
+        .ifNotReturn($c.querySelector('title').text().trim().run())
+        .run();
+    },
+    getIdentifier($c) {
+      // libraryId is part 4 of the reader URL
+      return $c.url().urlPart(4).run();
+    },
+    getOverviewUrl($c) {
+      return $c
+        .url()
+        .urlPart(4)
+        .setVariable('libraryId')
+        .string('/Libraries/MangaInfo/')
+        .concat($c.getVariable('libraryId').run())
+        .urlAbsolute()
+        .run();
+    },
+    getEpisode($c) {
+      return $c
+        .getGlobalVariable('kamiyomu_chapter')
+        .ifNotReturn($c.number(1).run())
+        .number()
+        .run();
+    },
+    getVolume($c) {
+      return $c
+        .getGlobalVariable('kamiyomu_volume')
+        .ifNotReturn($c.number(0).run())
+        .number()
+        .run();
+    },
+    getMalUrl($c) {
+      return $c.getGlobalVariable('kamiyomu_mal_url').ifNotReturn().run();
+    },
+    readerConfig: [
+      {
+        current: {
+          // KamiYomu appends ?page=N to the reader URL as you turn pages
+          mode: 'url',
+          regex: '(\\?|&)page=(\\d+)',
+          group: 2,
+        },
+        total: {
+          callback: () =>
+            (window as any).__kamiyomu_totalPages || 0,
+          mode: 'callback',
+        },
+      },
+    ],
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c.url().urlPart(3).equals('MangaInfo').run();
+    },
+    getTitle($c) {
+      return $c
+        .getGlobalVariable('kamiyomu_title')
+        .ifNotReturn($c.querySelector('h1, h2, h3').text().trim().run())
+        .run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlPart(4).run();
+    },
+    getImage($c) {
+      return $c
+        .querySelector('img[src*="/Collection/"]')
+        .getAttribute('src')
+        .ifNotReturn()
+        .urlAbsolute()
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('h1, h2, h3').uiAfter().run();
+    },
+    getMalUrl($c) {
+      return $c.getGlobalVariable('kamiyomu_mal_url').ifNotReturn().run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll('table tbody tr').run();
+    },
+    elementUrl($c) {
+      return $c.target().find('a').getAttribute('href').urlAbsolute().run();
+    },
+    elementEp($c) {
+      return $c
+        .target()
+        .find('td')
+        .first()
+        .text()
+        .trim()
+        .regex('(\\d+\\.?\\d*)$', 1)
+        .ifNotReturn()
+        .number()
+        .run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c
+        .requestProxy($c =>
+          handleRequest(
+            $c.setVariable('request').get('url').setVariable('requestUrl'),
+          ).run(),
+        )
+        .run();
+    },
+    listChange($c) {
+      return $c
+        .detectChanges(
+          $c.querySelectorAll('table tbody tr').length().run(),
+          $c.trigger().run(),
+        )
+        .run();
+    },
+  },
+};
+
+// Intercept KamiYomu's own API responses to extract manga/chapter metadata
+function handleRequest($c: ChibiGenerator<unknown>) {
+  return $c
+    .getVariable<string>('requestUrl')
+    // Collection endpoint: /Public/api/v1/Collection/{libraryId}
+    // but NOT the chapters sub-endpoint
+    .matches('/Public/api/v1/Collection/[^/]+(\\?|$)')
+    .ifThen($c => handleCollectionRequest($c).return().run())
+    .getVariable<string>('requestUrl')
+    // Chapter endpoint: /Public/api/v1/Collection/{libraryId}/chapters/{chapterDownloadId}
+    .matches('/Public/api/v1/Collection/[^/]+/chapters/')
+    .ifThen($c => handleChapterRequest($c).return().run());
+}
+
+function handleCollectionRequest($c: ChibiGenerator<unknown>) {
+  return $c
+    .getVariable('request')
+    .get('data')
+    .setVariable('collectionData')
+    // title
+    .get('manga')
+    .get('title')
+    .setGlobalVariable('kamiyomu_title')
+    // tracker links
+    .getVariable('collectionData')
+    .get('manga')
+    .get('links')
+    .setVariable('links')
+    // MAL
+    .getVariable<string>('links')
+    .get('MyAnimeList')
+    .ifThen($c =>
+      $c
+        .getVariable<string>('links')
+        .get('MyAnimeList')
+        .setGlobalVariable('kamiyomu_mal_url')
+        .return()
+        .run(),
+    )
+    // AniList
+    .getVariable<string>('links')
+    .get('AniList')
+    .setGlobalVariable('kamiyomu_mal_url')
+    .trigger();
+}
+
+function handleChapterRequest($c: ChibiGenerator<unknown>) {
+  return $c
+    .getVariable('request')
+    .get('data')
+    .setVariable('chapterData')
+    .get('number')
+    .setGlobalVariable('kamiyomu_chapter')
+    .getVariable('chapterData')
+    .get('volume')
+    .setGlobalVariable('kamiyomu_volume')
+    .trigger();
+}

--- a/src/pages-chibi/implementations/KamiYomu/style.less
+++ b/src/pages-chibi/implementations/KamiYomu/style.less
@@ -1,0 +1,1 @@
+// KamiYomu specific styles

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -94,6 +94,7 @@ import { AniGo } from './implementations/AniGo/main';
 import { Kuudere } from './implementations/Kuudere/main';
 import { BigSolo } from './implementations/BigSolo/main';
 import { Plex } from './implementations/Plex/main';
+import { KamiYomu } from './implementations/KamiYomu/main';
 import { allManga } from './implementations/allManga/main';
 import { GaiaFlix } from './implementations/GaiaFlix/main';
 import { AniZone } from './implementations/AniZone/main';
@@ -198,6 +199,7 @@ export const pages: { [key: string]: PageInterface } = {
   Kuudere,
   BigSolo,
   Plex,
+  KamiYomu,
   allManga,
   GaiaFlix,
   AniZone,

--- a/src/pages/KamiYomu/main.ts
+++ b/src/pages/KamiYomu/main.ts
@@ -1,0 +1,193 @@
+import { pageInterface } from '../pageInterface';
+
+async function apiCall(url: string) {
+  url = window.location.origin + url;
+  con.log('Api Call', url);
+  return api.request.xhr('GET', url);
+}
+
+const chapter = {
+  libraryId: '',
+  chapterDownloadId: '',
+  chapterNumber: 0,
+  volumeNumber: 0,
+  totalPages: 0,
+};
+
+const series = {
+  name: '',
+  links: {} as Record<string, string>,
+};
+
+// KamiYomu URL patterns:
+//   Reader:   /Reader/MangaReader/{libraryId}/chapter/{chapterDownloadId}
+//   Overview: /Libraries/MangaInfo/{libraryId}
+
+export const KamiYomu: pageInterface = {
+  name: 'KamiYomu',
+  domain: 'http://localhost:8090',
+  languages: ['Many'],
+  type: 'manga',
+  isSyncPage(url) {
+    return (
+      utils.urlPart(url, 3) === 'MangaReader' &&
+      utils.urlParam(url, 'incognito') !== 'true'
+    );
+  },
+  isOverviewPage(url) {
+    return utils.urlPart(url, 3) === 'MangaInfo';
+  },
+  sync: {
+    getTitle(_url) {
+      if (!series.name) throw 'No title';
+      return series.name;
+    },
+    getIdentifier(_url) {
+      if (!chapter.libraryId) throw 'No libraryId';
+      return chapter.libraryId;
+    },
+    getOverviewUrl(_url) {
+      return `${window.location.origin}/Libraries/MangaInfo/${chapter.libraryId}`;
+    },
+    getEpisode(_url) {
+      return chapter.chapterNumber || 1;
+    },
+    getVolume(_url) {
+      return chapter.volumeNumber || 0;
+    },
+    getMalUrl(provider) {
+      if (series.links['mal']) return series.links['mal'];
+      if (provider === 'ANILIST' && series.links['al']) return series.links['al'];
+      if (provider === 'KITSU' && series.links['kt']) return series.links['kt'];
+      return false;
+    },
+    readerConfig: [
+      {
+        current: {
+          mode: 'url',
+          regex: '(\\?|&)page=(\\d+)',
+          group: 2,
+        },
+        total: {
+          callback: () => chapter.totalPages as any,
+          mode: 'callback',
+        },
+      },
+    ],
+  },
+  overview: {
+    getTitle(_url) {
+      if (!series.name) throw 'No title';
+      return series.name;
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 4);
+    },
+    uiSelector(selector) {
+      j.$('h1, h2, h3').first().after(j.html(selector));
+    },
+    getMalUrl(provider) {
+      return KamiYomu.sync.getMalUrl!(provider);
+    },
+    list: {
+      offsetHandler: false,
+      elementsSelector() {
+        return j.$('table tbody tr, .chapter-row');
+      },
+      elementUrl(selector) {
+        return utils.absoluteLink(
+          selector.find('a').first().attr('href'),
+          KamiYomu.domain,
+        );
+      },
+      elementEp(selector) {
+        const text = selector.find('td, .chapter-number').first().text().trim();
+        return Number(text.replace(/[^\d.]/g, '')) || 0;
+      },
+    },
+  },
+  init(page) {
+    api.storage.addStyle(
+      require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
+    );
+
+    utils.changeDetect(load, () => window.location.href.split('?')[0].split('#')[0]);
+    load();
+
+    function resetState() {
+      chapter.libraryId = '';
+      chapter.chapterDownloadId = '';
+      chapter.chapterNumber = 0;
+      chapter.volumeNumber = 0;
+      chapter.totalPages = 0;
+      series.name = '';
+      series.links = {};
+    }
+
+    function setLinksFromManga(manga: any) {
+      if (!manga || !manga.links) return;
+      Object.values(manga.links as Record<string, string>).forEach((linkUrl: string) => {
+        if (!linkUrl) return;
+        if (linkUrl.includes('myanimelist.net/manga') && !series.links['mal'])
+          series.links['mal'] = linkUrl;
+        else if (linkUrl.includes('anilist.co/manga') && !series.links['al'])
+          series.links['al'] = linkUrl;
+        else if (linkUrl.includes('kitsu.app/manga') && !series.links['kt'])
+          series.links['kt'] = linkUrl;
+      });
+    }
+
+    async function loadCollectionItem(libraryId: string) {
+      const res = await apiCall(`/Public/api/v1/Collection/${libraryId}`);
+      const data = JSON.parse(res.responseText);
+      con.m('Collection').log(data);
+      if (data.manga) {
+        series.name = data.manga.title || '';
+        setLinksFromManga(data.manga);
+      }
+    }
+
+    async function load() {
+      resetState();
+      page.reset();
+
+      const url = window.location.href;
+
+      if (KamiYomu.isSyncPage(url)) {
+        // /Reader/MangaReader/{libraryId}/chapter/{chapterDownloadId}
+        chapter.libraryId = utils.urlPart(url, 4);
+        chapter.chapterDownloadId = utils.urlPart(url, 6);
+        if (!chapter.libraryId || !chapter.chapterDownloadId) return;
+
+        try {
+          const chRes = await apiCall(
+            `/Public/api/v1/Collection/${chapter.libraryId}/chapters/${chapter.chapterDownloadId}`,
+          );
+          const chData = JSON.parse(chRes.responseText);
+          con.m('Chapter').log(chData);
+          chapter.chapterNumber = chData.number ?? 0;
+          chapter.volumeNumber = chData.volume ?? 0;
+          await loadCollectionItem(chapter.libraryId);
+        } catch (e) {
+          con.error('KamiYomu init error', e);
+          return;
+        }
+
+        page.handlePage();
+      } else if (KamiYomu.isOverviewPage!(url)) {
+        // /Libraries/MangaInfo/{libraryId}
+        chapter.libraryId = utils.urlPart(url, 4);
+        if (!chapter.libraryId) return;
+
+        try {
+          await loadCollectionItem(chapter.libraryId);
+        } catch (e) {
+          con.error('KamiYomu overview init error', e);
+          return;
+        }
+
+        page.handlePage();
+      }
+    }
+  },
+};

--- a/src/pages/KamiYomu/meta.json
+++ b/src/pages/KamiYomu/meta.json
@@ -1,0 +1,5 @@
+{
+  "urls": {
+    "match": ["*://*/Reader/MangaReader/*", "*://*/Libraries/MangaInfo/*"]
+  }
+}

--- a/src/pages/KamiYomu/style.less
+++ b/src/pages/KamiYomu/style.less
@@ -1,0 +1,1 @@
+// KamiYomu specific styles

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -100,6 +100,7 @@ import { AnimesOnline } from './AnimesOnline/main';
 import { Latanime } from './Latanime/main';
 import { MangaRead } from './MangaRead/main';
 import { Kavita } from './Kavita/main';
+import { KamiYomu } from './KamiYomu/main';
 import { Aninexus } from './Aninexus/main';
 import { AniDream } from './AniDream/main';
 
@@ -206,6 +207,7 @@ export const pages = {
   Latanime,
   MangaRead,
   Kavita,
+  KamiYomu,
   Aninexus,
   AniDream,
 };


### PR DESCRIPTION
## Description

This PR adds support for [KamiYomu](https://github.com/KamiYomu/KamiYomu), a self-hosted, extensible manga reader and downloader with plugin-based crawler agent support.

## Pages added

- `src/pages/KamiYomu/main.ts`
- `src/pages/KamiYomu/meta.json`
- `src/pages/KamiYomu/style.less`

## How it works

KamiYomu exposes a public REST API that this implementation uses to fetch manga and chapter metadata.

**URL patterns detected:**
- Reader: `/Reader/MangaReader/{libraryId}/chapter/{chapterDownloadId}`
- Overview: `/Libraries/MangaInfo/{libraryId}`

**Features:**
- Fetches chapter number and volume from `/Public/api/v1/Collection/{libraryId}/chapters/{chapterDownloadId}`
- Fetches manga title and tracker links (AniList, MAL, Kitsu) from `/Public/api/v1/Collection/{libraryId}`
- Tracks reading progress via the `?page=N` URL parameter
- Works with any self-hosted instance using wildcard URL matching
- Supports overview page with chapter list

## Testing

Tested against a self-hosted KamiYomu instance (v1.2.0) running on aarch64 (Orange Pi 5).