### PR TITLE
AnimeNexus main.ts -> Fix missing search: '' for Quicklink functionality.

### DIFF
--- a/src/pages-chibi/implementations/AnimeNexus/main.ts
+++ b/src/pages-chibi/implementations/AnimeNexus/main.ts
@@ -9,6 +9,7 @@ export const AnimeNexus: PageInterface = {
   urls: {
     match: ['*://anime.nexus/*'],
   },
+  search: 'https://anime.nexus/series?search={searchterm}',
   sync: {
     isSyncPage($c) {
       return $c


### PR DESCRIPTION
Without this it shows in settings but not on anime in the main ui.