### PR TITLE
Add miruro.bz to Miruro domains

### DIFF
--- a/src/pages-chibi/implementations/AniKoto/main.ts
+++ b/src/pages-chibi/implementations/AniKoto/main.ts
@@ -1,0 +1,106 @@
+import type { ChibiGenerator } from '../../../chibiScript/ChibiGenerator';
+import { PageInterface } from '../../pageInterface';
+
+export const anikoto: PageInterface = {
+  name: 'AniKoto',
+  domain: 'https://anikoto.cz',
+  languages: ['English'],
+  type: 'anime',
+  urls: {
+    match: ['*://*.anikoto.cz/*', '*://*.anikototv.to/*'],
+  },
+  search: 'https://anikoto.cz/filter?keyword={searchtermPlus}',
+  sync: {
+    isSyncPage($c) {
+      return getJsonData($c).get('page').equals('episode').run();
+    },
+    getTitle($c) {
+      return getJsonData($c).get('name').run();
+    },
+    getIdentifier($c) {
+      return getJsonData($c).get('anime_id').run();
+    },
+    getOverviewUrl($c) {
+      return getJsonData($c).get('series_url').ifNotReturn().string().urlAbsolute().run();
+    },
+    getEpisode($c) {
+      return getJsonData($c).get('episode').number().run();
+    },
+    getImage($c) {
+      return $c.querySelector('[itemprop="image"]').getAttribute('src').ifNotReturn().run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('#player-control').uiAfter().run();
+    },
+    nextEpUrl($c) {
+      return $c
+        .querySelector('.eplist .active')
+        .parent()
+        .next()
+        .ifNotReturn()
+        .find('a')
+        .getAttribute('href')
+        .ifNotReturn()
+        .urlAbsolute()
+        .run();
+    },
+    getMalUrl($c) {
+      const getMalId = getJsonData($c)
+        .get('mal_id')
+        .number()
+        .ifNotReturn()
+        .string('https://myanimelist.net/anime/<identifier>')
+        .replace('<identifier>', getJsonData($c).get('mal_id').run())
+        .run();
+
+      const getAnilistId = $c
+        .provider()
+        .equals('ANILIST')
+        .ifNotReturn()
+        .string('https://anilist.co/anime/<identifier>')
+        .replace('<identifier>', getJsonData($c).get('al_id').run())
+        .run();
+
+      return $c.coalesce($c.fn(getMalId).run(), $c.fn(getAnilistId).run()).ifNotReturn().run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll('.eplist a').run();
+    },
+    elementUrl($c) {
+      return $c.getAttribute('href').ifNotReturn().urlAbsolute().run();
+    },
+    elementEp($c) {
+      return $c.getAttribute('num').number().run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c
+        .domReady()
+        .detectChanges(
+          $c.querySelector('#syncData').ifNotReturn().text().trim().run(),
+          $c.trigger().run(),
+        )
+        .trigger()
+        .run();
+    },
+    syncIsReady($c) {
+      return $c
+        .querySelector('#syncData')
+        .ifNotReturn()
+        .text()
+        .contains('\\/\\/')
+        .ifNotReturn($c.trigger().return().run())
+        .run();
+    },
+  },
+};
+
+function getJsonData($c: ChibiGenerator<unknown>) {
+  return $c.querySelector('#syncData').ifNotReturn().text().jsonParse();
+}

--- a/src/pages-chibi/implementations/AniKoto/main.ts
+++ b/src/pages-chibi/implementations/AniKoto/main.ts
@@ -18,19 +18,19 @@ export const anikoto: PageInterface = {
       return getJsonData($c).get('name').run();
     },
     getIdentifier($c) {
-      return getJsonData($c).get('anime_id').run();
+      return $c.url().urlPart(4).run();
     },
     getOverviewUrl($c) {
       return getJsonData($c).get('series_url').ifNotReturn().string().urlAbsolute().run();
     },
     getEpisode($c) {
-      return getJsonData($c).get('episode').number().run();
+      return $c.url().urlPart(6).replaceRegex('ep-', '').number().run();
     },
     getImage($c) {
       return $c.querySelector('[itemprop="image"]').getAttribute('src').ifNotReturn().run();
     },
     uiInjection($c) {
-      return $c.querySelector('#player-control').uiAfter().run();
+      return $c.querySelector('#controls').uiAfter().run();
     },
     nextEpUrl($c) {
       return $c

--- a/src/pages-chibi/implementations/AniKoto/main.ts
+++ b/src/pages-chibi/implementations/AniKoto/main.ts
@@ -1,4 +1,3 @@
-import type { ChibiGenerator } from '../../../chibiScript/ChibiGenerator';
 import { PageInterface } from '../../pageInterface';
 
 export const anikoto: PageInterface = {
@@ -12,19 +11,19 @@ export const anikoto: PageInterface = {
   search: 'https://anikoto.cz/filter?keyword={searchtermPlus}',
   sync: {
     isSyncPage($c) {
-      return getJsonData($c).get('page').equals('episode').run();
+      return $c.and($c.url().urlPart(3).equals('watch').run(), $c.url().urlPart(5).boolean().run()).run();
     },
     getTitle($c) {
-      return getJsonData($c).get('name').run();
+      return $c.querySelector('h1[itemprop="name"]').text().trim().run();
     },
     getIdentifier($c) {
       return $c.url().urlPart(4).run();
     },
     getOverviewUrl($c) {
-      return getJsonData($c).get('series_url').ifNotReturn().string().urlAbsolute().run();
+      return $c.url().replaceRegex('/ep-\\d+$', '').run();
     },
     getEpisode($c) {
-      return $c.url().urlPart(6).replaceRegex('ep-', '').number().run();
+      return $c.url().urlPart(5).replaceRegex('ep-', '').number().run();
     },
     getImage($c) {
       return $c.querySelector('[itemprop="image"]').getAttribute('src').ifNotReturn().run();
@@ -34,7 +33,7 @@ export const anikoto: PageInterface = {
     },
     nextEpUrl($c) {
       return $c
-        .querySelector('.eplist .active')
+        .querySelector('#w-episodes .active')
         .parent()
         .next()
         .ifNotReturn()
@@ -45,34 +44,21 @@ export const anikoto: PageInterface = {
         .run();
     },
     getMalUrl($c) {
-      const getMalId = getJsonData($c)
-        .get('mal_id')
-        .number()
-        .ifNotReturn()
+      return $c
         .string('https://myanimelist.net/anime/<identifier>')
-        .replace('<identifier>', getJsonData($c).get('mal_id').run())
+        .replace('<identifier>', $c.querySelector('#w-episodes .active').getAttribute('data-mal').ifNotReturn().run())
         .run();
-
-      const getAnilistId = $c
-        .provider()
-        .equals('ANILIST')
-        .ifNotReturn()
-        .string('https://anilist.co/anime/<identifier>')
-        .replace('<identifier>', getJsonData($c).get('al_id').run())
-        .run();
-
-      return $c.coalesce($c.fn(getMalId).run(), $c.fn(getAnilistId).run()).ifNotReturn().run();
     },
   },
   list: {
     elementsSelector($c) {
-      return $c.querySelectorAll('.eplist a').run();
+      return $c.querySelectorAll('#w-episodes .ep-range a').run();
     },
     elementUrl($c) {
       return $c.getAttribute('href').ifNotReturn().urlAbsolute().run();
     },
     elementEp($c) {
-      return $c.getAttribute('num').number().run();
+      return $c.getAttribute('data-num').number().run();
     },
   },
   lifecycle: {
@@ -80,27 +66,10 @@ export const anikoto: PageInterface = {
       return $c.addStyle(require('./style.less?raw').toString()).run();
     },
     ready($c) {
-      return $c
-        .domReady()
-        .detectChanges(
-          $c.querySelector('#syncData').ifNotReturn().text().trim().run(),
-          $c.trigger().run(),
-        )
-        .trigger()
-        .run();
+      return $c.domReady().detectURLChanges($c.trigger().run()).trigger().run();
     },
     syncIsReady($c) {
-      return $c
-        .querySelector('#syncData')
-        .ifNotReturn()
-        .text()
-        .contains('\\/\\/')
-        .ifNotReturn($c.trigger().return().run())
-        .run();
+      return $c.querySelector('#w-episodes .active').boolean().run();
     },
   },
 };
-
-function getJsonData($c: ChibiGenerator<unknown>) {
-  return $c.querySelector('#syncData').ifNotReturn().text().jsonParse();
-}

--- a/src/pages-chibi/implementations/AniKoto/style.less
+++ b/src/pages-chibi/implementations/AniKoto/style.less
@@ -1,0 +1,12 @@
+@import './../pages';
+
+@boxBackground: var(--bs-tertiary-bg);
+
+@activeEp: #002e7459 !important;
+
+#malp {
+  background-color: var(--bs-body-bg);
+  padding: 1.35rem;
+  margin: 0;
+  min-height: 90px;
+}

--- a/src/pages-chibi/implementations/AniKoto/test.json
+++ b/src/pages-chibi/implementations/AniKoto/test.json
@@ -1,0 +1,71 @@
+{
+  "title": "AniKoto",
+  "url": "https://anikoto.cz",
+  "offline": true,
+  "testCases": [
+    {
+      "url": "https://anikoto.cz/watch/one-piece-odmau/ep-5",
+      "expected": {
+        "sync": true,
+        "title": "One Piece",
+        "identifier": "one-piece-odmau",
+        "overviewUrl": "https://anikoto.cz/watch/one-piece-odmau",
+        "nextEpUrl": "https://anikoto.cz/watch/one-piece-odmau/ep-6",
+        "episode": 5,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/21",
+        "epList": {
+          "5": "https://anikoto.cz/watch/one-piece-odmau/ep-5"
+        }
+      }
+    },
+    {
+      "url": "https://anikoto.cz/watch/one-piece-odmau/ep-1159",
+      "expected": {
+        "sync": true,
+        "title": "One Piece",
+        "identifier": "one-piece-odmau",
+        "overviewUrl": "https://anikoto.cz/watch/one-piece-odmau",
+        "nextEpUrl": "https://anikoto.cz/watch/one-piece-odmau/ep-1160",
+        "episode": 1159,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/21",
+        "epList": {
+          "1159": "https://anikoto.cz/watch/one-piece-odmau/ep-1159"
+        }
+      }
+    },
+    {
+      "url": "https://anikoto.cz/watch/violet-evergarden-uxbvu/ep-1",
+      "expected": {
+        "sync": true,
+        "title": "Violet Evergarden",
+        "identifier": "violet-evergarden-uxbvu",
+        "overviewUrl": "https://anikoto.cz/watch/violet-evergarden-uxbvu",
+        "nextEpUrl": "https://anikoto.cz/watch/violet-evergarden-uxbvu/ep-2",
+        "episode": 1,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/33352",
+        "epList": {
+          "1": "https://anikoto.cz/watch/violet-evergarden-uxbvu/ep-1"
+        }
+      }
+    },
+    {
+      "url": "https://anikoto.cz/watch/solo-leveling-ilh08/ep-9",
+      "expected": {
+        "sync": true,
+        "title": "Solo Leveling",
+        "identifier": "solo-leveling-ilh08",
+        "overviewUrl": "https://anikoto.cz/watch/solo-leveling-ilh08",
+        "nextEpUrl": "https://anikoto.cz/watch/solo-leveling-ilh08/ep-10",
+        "episode": 9,
+        "uiSelector": true,
+        "malUrl": "https://myanimelist.net/anime/52299",
+        "epList": {
+          "9": "https://anikoto.cz/watch/solo-leveling-ilh08/ep-9"
+        }
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/implementations/Miruro/main.ts
+++ b/src/pages-chibi/implementations/Miruro/main.ts
@@ -2,11 +2,12 @@ import { PageInterface } from '../../pageInterface';
 
 export const Miruro: PageInterface = {
   name: 'Miruro',
-  domain: ['https://www.miruro.to', 'https://www.miruro.tv', 'https://www.miruro.online'],
+  // Add new official domain from https://www.miruro.com/#domains
+  domain: ['https://www.miruro.to', 'https://www.miruro.tv', 'https://www.miruro.online', 'https://www.miruro.bz'],
   languages: ['English'],
   type: 'anime',
   urls: {
-    match: ['*://*.miruro.to/*', '*://*.miruro.tv/*', '*://*.miruro.online/*'],
+    match: ['*://*.miruro.to/*', '*://*.miruro.tv/*', '*://*.miruro.online/*', '*://*.miruro.bz/*'],
   },
   search: 'https://www.miruro.to/search?query={searchtermPlus}',
   sync: {

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -2,6 +2,7 @@ import { PageInterface } from './pageInterface';
 
 import { animeav1 } from './implementations/animeav1/main';
 import { anicrush } from './implementations/anicrush/main';
+import { anikoto } from './implementations/AniKoto/main';
 import { mangaNato } from './implementations/mangaNato/main';
 import { gojo } from './implementations/gojo/main';
 import { animeLib } from './implementations/animeLib/main';
@@ -108,6 +109,7 @@ import { TopManhua } from './implementations/TopManhua/main';
 export const pages: { [key: string]: PageInterface } = {
   animeav1,
   anicrush,
+  anikoto,
   mangaNato,
   gojo,
   animeLib,

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -897,4 +897,8 @@ module.exports = {
   allManga: {
     match: ['*://allanime.day/*', '*://allanime.uns.bio/*'],
   },
+  //AniKoto
+  vidcloud: {
+    match: ['*://vidwish.live/*'],
+  },
 };


### PR DESCRIPTION
Register the new official Miruro domain (https://www.miruro.bz) in the Miruro page config. This updates the domain list and the URL match patterns in src/pages-chibi/implementations/Miruro/main.ts and includes a comment noting the source of the new domain.