### PR TITLE
Crunchyroll: fix SPA detection + per-arc episode numbering

### DIFF
--- a/src/pages-chibi/implementations/Crunchyroll/main.ts
+++ b/src/pages-chibi/implementations/Crunchyroll/main.ts
@@ -52,7 +52,11 @@ export const Crunchyroll: PageInterface = {
       return getJsonData($c).get('partOfSeason').get('@id').run();
     },
     getEpisode($c) {
-      return getJsonData($c).get('episodeNumber').number().run();
+      return getJsonData($c)
+        .get('episodeNumber')
+        .number()
+        .calculate('+', getEpisodeRangeOffset($c).run())
+        .run();
     },
     nextEpUrl($c) {
       return $c
@@ -71,7 +75,7 @@ export const Crunchyroll: PageInterface = {
       return $c.addStyle(require('./style.less?raw').toString()).run();
     },
     ready($c) {
-      return $c.detectChanges($c.title().run(), $c.trigger().run()).domReady().trigger().run();
+      return $c.detectChanges($c.url().run(), $c.trigger().run()).domReady().trigger().run();
     },
   },
 };
@@ -86,6 +90,18 @@ function getSeasonName($c: ChibiGenerator<unknown>) {
 
 function getSeriesName($c: ChibiGenerator<unknown>) {
   return getJsonData($c).get('partOfSeries').get('name').string();
+}
+
+function hasEpisodeRange($c: ChibiGenerator<unknown>) {
+  return getSeasonName($c).matches('\\(\\d+-\\d+\\)');
+}
+
+function getEpisodeRangeOffset($c: ChibiGenerator<unknown>) {
+  return $c.if(
+    hasEpisodeRange($c).run(),
+    getSeasonName($c).regex('\\((\\d+)-\\d+\\)', 1).number().calculate('-', 1).run(),
+    $c.number(0).run(),
+  );
 }
 
 function getJsonData($c: ChibiGenerator<unknown>) {

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -6,6 +6,16 @@ export type PlayerTime = {
   paused: boolean;
 };
 
+function collectVideos(root: Document | ShadowRoot): HTMLVideoElement[] {
+  const found: HTMLVideoElement[] = Array.from(root.querySelectorAll('video'));
+  const all = root.querySelectorAll('*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i] as Element;
+    if (el.shadowRoot) found.push(...collectVideos(el.shadowRoot));
+  }
+  return found;
+}
+
 export class PlayerSingleton {
   // eslint-disable-next-line es-x/no-class-static-fields
   private static instance: PlayerSingleton = new PlayerSingleton();
@@ -34,7 +44,7 @@ export class PlayerSingleton {
 
   public startTracking() {
     setInterval(() => {
-      const players = document.getElementsByTagName('video');
+      const players = collectVideos(document);
       for (let i = 0; i < players.length; i++) {
         const player: HTMLVideoElement = players[i];
         const { duration } = player;

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -6,14 +6,21 @@ export type PlayerTime = {
   paused: boolean;
 };
 
-function collectVideos(root: Document | ShadowRoot): HTMLVideoElement[] {
-  const found: HTMLVideoElement[] = Array.from(root.querySelectorAll('video'));
+function findUsableVideo(root: Document | ShadowRoot): HTMLVideoElement | null {
+  const direct = root.querySelectorAll('video');
+  for (let i = 0; i < direct.length; i++) {
+    const v = direct[i];
+    if (v.duration && v.duration > 60) return v;
+  }
   const all = root.querySelectorAll('*');
   for (let i = 0; i < all.length; i++) {
     const el = all[i] as Element;
-    if (el.shadowRoot) found.push(...collectVideos(el.shadowRoot));
+    if (el.shadowRoot) {
+      const found = findUsableVideo(el.shadowRoot);
+      if (found) return found;
+    }
   }
-  return found;
+  return null;
 }
 
 export class PlayerSingleton {
@@ -44,25 +51,18 @@ export class PlayerSingleton {
 
   public startTracking() {
     setInterval(() => {
-      const players = collectVideos(document);
-      for (let i = 0; i < players.length; i++) {
-        const player: HTMLVideoElement = players[i];
-        const { duration } = player;
-        const current = player.currentTime;
-        const { paused } = player;
-
-        if (duration && duration > 60) {
-          const item = {
-            current,
-            duration,
-            paused,
-          };
-          logger.debug(window.location.href, item);
-          this.currentPlayer = player;
-          this.notifyListeners(item, player);
-          playerExtras(item, player);
-          return;
-        }
+      const player = findUsableVideo(document);
+      if (player) {
+        const item = {
+          current: player.currentTime,
+          duration: player.duration,
+          paused: player.paused,
+        };
+        logger.debug(window.location.href, item);
+        this.currentPlayer = player;
+        this.notifyListeners(item, player);
+        playerExtras(item, player);
+        return;
       }
       this.currentPlayer = null;
     }, 1000);

--- a/test/src/pages-chibi/Crunchyroll.test.ts
+++ b/test/src/pages-chibi/Crunchyroll.test.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import { $c, ChibiJson } from '../../../src/chibiScript/ChibiGenerator';
+import { ChibiConsumer } from '../../../src/chibiScript/ChibiConsumer';
+
+// These tests validate the chibi composition used in Crunchyroll's getEpisode
+// for arc-grouped long-running shows where partOfSeason.name encodes an
+// absolute episode range like "Thriller Bark (337-381)". The composition
+// mirrors getEpisodeRangeOffset / hasEpisodeRange in
+// src/pages-chibi/implementations/Crunchyroll/main.ts but feeds a literal
+// season name instead of reading it from JSON-LD, so the assertion isolates
+// the offset logic from DOM/JSON-LD parsing.
+
+function offsetFromSeasonName(seasonName: string) {
+  const code = $c
+    .if(
+      $c.string(seasonName).matches('\\(\\d+-\\d+\\)').run(),
+      $c
+        .string(seasonName)
+        .regex('\\((\\d+)-\\d+\\)', 1)
+        .number()
+        .calculate('-', 1)
+        .run(),
+      $c.number(0).run(),
+    )
+    .run();
+  return generateAndExecute(code).run();
+}
+
+function absoluteEpisode(seasonName: string, rawEpisodeNumber: number) {
+  const code = $c
+    .number(rawEpisodeNumber)
+    .calculate(
+      '+',
+      $c
+        .if(
+          $c.string(seasonName).matches('\\(\\d+-\\d+\\)').run(),
+          $c
+            .string(seasonName)
+            .regex('\\((\\d+)-\\d+\\)', 1)
+            .number()
+            .calculate('-', 1)
+            .run(),
+          $c.number(0).run(),
+        )
+        .run(),
+    )
+    .run();
+  return generateAndExecute(code).run();
+}
+
+describe('Crunchyroll arc-range episode offset', () => {
+  describe('offsetFromSeasonName', () => {
+    it('returns rangeStart - 1 when season name encodes an absolute range', () => {
+      // One Piece "Thriller Bark" arc: episodes 337-381 absolute
+      expect(offsetFromSeasonName('Thriller Bark (337-381)')).to.equal(336);
+    });
+
+    it('handles a range starting at 1 (first arc)', () => {
+      expect(offsetFromSeasonName('East Blue (1-61)')).to.equal(0);
+    });
+
+    it('handles a range deep into a long-running series', () => {
+      expect(offsetFromSeasonName('Wano (892-1086)')).to.equal(891);
+    });
+
+    it('returns 0 when season name has no range pattern', () => {
+      expect(offsetFromSeasonName('Naruto Season 3')).to.equal(0);
+    });
+
+    it('returns 0 for typical first-cour season names', () => {
+      expect(offsetFromSeasonName('Re:ZERO -Starting Life in Another World-')).to.equal(0);
+    });
+
+    it('returns 0 when parentheses contain non-range content', () => {
+      expect(offsetFromSeasonName('Yano-kun (Subbed)')).to.equal(0);
+    });
+
+    it('returns 0 when only a single number is in parentheses', () => {
+      expect(offsetFromSeasonName('Some Show (12)')).to.equal(0);
+    });
+  });
+
+  describe('absoluteEpisode (composed: episodeNumber + offset)', () => {
+    it('reconstructs absolute episode for One Piece Thriller Bark E43 → 379', () => {
+      // Reproduction case: the 43rd episode of the Thriller Bark arc (337-381)
+      // displays on Crunchyroll as "E379" and is tracked by MAL as episode 379.
+      expect(absoluteEpisode('Thriller Bark (337-381)', 43)).to.equal(379);
+    });
+
+    it('leaves episode unchanged for non-arc-grouped shows', () => {
+      // Re:ZERO Season 3 episode 1 → still 1; no offset applied.
+      expect(
+        absoluteEpisode('Re:ZERO -Starting Life in Another World-', 1),
+      ).to.equal(1);
+    });
+
+    it('leaves episode unchanged for Naruto-style "Season N" naming', () => {
+      // Crunchyroll labels arcs as "Naruto Season 3" without an embedded range,
+      // so the raw episodeNumber from JSON-LD is preserved.
+      expect(absoluteEpisode('Naruto Season 3', 55)).to.equal(55);
+    });
+
+    it('preserves first-arc numbering when range starts at 1', () => {
+      expect(absoluteEpisode('East Blue (1-61)', 8)).to.equal(8);
+    });
+  });
+});
+
+function generateAndExecute(input: ChibiJson<any>) {
+  const json = JSON.stringify(input);
+  const script = JSON.parse(json);
+  const consumer = new ChibiConsumer(script);
+  return consumer;
+}


### PR DESCRIPTION
Fixes #3837 

## Root causes

Two independent bugs in [`src/pages-chibi/implementations/Crunchyroll/main.ts`](src/pages-chibi/implementations/Crunchyroll/main.ts), plus one defensive change in the global player tracker.

### Bug 1 — SPA change detection keys off `document.title`

```ts
ready($c) {
  return $c.detectChanges($c.title().run(), $c.trigger().run()).domReady().trigger().run();
}
```

`detectChanges` polls every 500ms and only re-fires the trigger when the JSON-stringified target changes. On modern Crunchyroll, `document.title` either does not change reliably between episodes or only changes to a generic value. When the trigger doesn't re-fire, `handlePage()` never re-runs after the first paint, so:

- `getEpisode` is never re-evaluated → episode number locked at first-load value.
- `isSyncPage` is never re-evaluated either → `state.on` never gets promoted to `'SYNC'` after a home → watch transition → the `state.on === 'SYNC'` branch in [`syncPage.ts:197-216`](src/pages-sync/syncPage.ts#L197-L216) — which is what registers `PlayerSingleton.startTracking()` and the auto-next-ep listener — never runs → no progress overlay, no auto-update.

Other Chibi handlers that work correctly across SPA navigation (animeLib, mangaLib, TritiniaScans) key `detectChanges` off the URL instead. Crunchyroll watch URLs encode a unique watch ID (`/watch/<ID>/<slug>`), so URL-based detection is reliable for every transition.

Related: [#3268](https://github.com/MALSync/MALSync/issues/3268) showed the tab title sticking on a generic "Season 1" string for Fall 2025 anime — same root cause, narrower visible symptom.

### Bug 2 — `episodeNumber` is per-season, not absolute, for arc-grouped shows

```ts
getEpisode($c) {
  return getJsonData($c).get('episodeNumber').number().run();
}
```

For long-running shows that Crunchyroll splits into pseudo-seasons by arc, the JSON-LD `episodeNumber` is the index *within* that arc, not the absolute series number. For the test page above it reports `43` (the 43rd episode of the Thriller Bark arc), even though MAL/users track it as 379.

Even with a correct MAL mapping (via Correction Search or otherwise), the auto-sync threshold check compares this number against the user's current MAL list value. If MAL is at episode 363 and the page reports 43, the check sees `43 < 363` and silently no-ops. The list never moves no matter how long you watch.

Crunchyroll itself encodes the answer right in `partOfSeason.name`: `"Thriller Bark (337-381)"`. The first number is the absolute starting episode of that arc.

## Fix

### Bug 1 — switch `detectChanges` target to URL

```diff
-return $c.detectChanges($c.title().run(), $c.trigger().run()).domReady().trigger().run();
+return $c.detectChanges($c.url().run(), $c.trigger().run()).domReady().trigger().run();
```

### Bug 2 — derive absolute episode from the season-name range when present

When `partOfSeason.name` matches `\(\d+-\d+\)`, treat the first number as the absolute starting episode of the arc and add `(start - 1)` to `episodeNumber`. Otherwise, return `episodeNumber` unchanged.

```ts
function hasEpisodeRange($c: ChibiGenerator<unknown>) {
  return getSeasonName($c).matches('\\(\\d+-\\d+\\)');
}

function getEpisodeRangeOffset($c: ChibiGenerator<unknown>) {
  return $c.if(
    hasEpisodeRange($c).run(),
    getSeasonName($c).regex('\\((\\d+)-\\d+\\)', 1).number().calculate('-', 1).run(),
    $c.number(0).run(),
  );
}
```

```ts
getEpisode($c) {
  return getJsonData($c)
    .get('episodeNumber')
    .number()
    .calculate('+', getEpisodeRangeOffset($c).run())
    .run();
},
```

When the season name has no `(start-end)` pattern (Re:ZERO Season 3, GUILTY GEAR Season 1, Yano-kun Season 1, Naruto Season N, etc.), `offset = 0` and behavior is byte-identical to before — all existing fixtures in [`tests.json`](src/pages-chibi/implementations/Crunchyroll/tests.json) pass unchanged.

`getTitle`, `getIdentifier`, and the search/correction flow are untouched. Correction Search remains the expected mechanism for resolving the Crunchyroll → MAL mapping.

### Bonus — shadow-DOM-pierce the player tracker (defensive, separate concern)

`PlayerSingleton.startTracking()` in [`src/utils/player.ts`](src/utils/player.ts) used `document.getElementsByTagName('video')`, which does not cross shadow roots. Crunchyroll's Vilos player wraps `<video>` in a shadow tree on some configurations. The hardened version is strictly broader (any page that worked before still works) and is needed if Crunchyroll moves the element fully behind a shadow root.

```diff
+function collectVideos(root: Document | ShadowRoot): HTMLVideoElement[] {
+  const found: HTMLVideoElement[] = Array.from(root.querySelectorAll('video'));
+  const all = root.querySelectorAll('*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i] as Element;
+    if (el.shadowRoot) found.push(...collectVideos(el.shadowRoot));
+  }
+  return found;
+}
@@
 public startTracking() {
   setInterval(() => {
-    const players = document.getElementsByTagName('video');
+    const players = collectVideos(document);
     for (let i = 0; i < players.length; i++) {
```

Independent from the Crunchyroll-specific fix; happy to split into its own PR if preferred.

## Verification

- `npm run lint:vue` — clean.
- `npm run test:ts` — 660 pass. 1 pre-existing failure unrelated (network-dependent "Full Search" timeout), 1 pre-existing-disabled file (`test/src/background/customDomain.test.ts` has a top-level `return;` that newer Node rejects; unrelated).
- All existing fixtures in [`Crunchyroll/tests.json`](src/pages-chibi/implementations/Crunchyroll/tests.json) (Re:ZERO S3 ep 66, GUILTY GEAR ep 1, Ai-Mai-Mi ep 3, Katana Maidens ep 12, Yano-kun ep 1, Wild Last Boss ep 1) hit the no-range branch and produce identical output to before.
- Live-tested in Chrome on the failing One Piece episode above:
  - Before: chibi handler only fires on first paint; episode locked; no progress overlay.
  - After: handler fires on every SPA navigation; detected episode is 379 (43 + 336); auto-update fires after watch threshold; progress overlay tracks correctly.
- Spot-check on Naruto (`partOfSeason.name = "Naruto Season 3"`, no range): `hasRange = false`, episode unchanged, no behavior change.
