### PR TITLE
fix(BStation): adjust box background for light theme

### DIFF
--- a/src/pages-chibi/implementations/Bstation/style.less
+++ b/src/pages-chibi/implementations/Bstation/style.less
@@ -1,5 +1,7 @@
 @import './../pages';
 
-@boxBackground: rgba(13, 16, 32, 0.92);
+@boxBackground: #f3f4f6;
+@boxOptionsBackground: #ffffff;
+@boxOptionsFontColor: #333333;
 @highlightStyle: 2;
 @activeEp: #ff6ea7;


### PR DESCRIPTION
﻿Adjust the MALSync box background on BStation to better match the site's light-only theme.

BStation sets its page background to `#fafafa`, so the previous near-black MALSync box background looked like a dark-mode style on a light page. This changes the box surface to a light gray and explicitly sets select option colors for readability.

Tested with:
- `node node_modules/stylelint/bin/stylelint.mjs src/pages-chibi/implementations/Bstation/style.less`
- Manual Puppeteer DOM check against BStation's `#fafafa` page background; MALSync box computed as `rgb(243, 244, 246)` with readable option colors.
