### PR TITLE
feat(chibi): add DMM TV support

### DIFF
--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -1,0 +1,110 @@
+import type { ChibiGenerator } from '../../../chibiScript/ChibiGenerator';
+import { PageInterface } from '../../pageInterface';
+
+const domain = 'https://tv.dmm.com';
+
+export const DMMTV: PageInterface = {
+  name: 'DMM TV',
+  domain,
+  languages: ['Japanese'],
+  type: 'anime',
+  urls: {
+    match: ['*://tv.dmm.com/vod/*'],
+  },
+  search: 'https://tv.dmm.com/vod/search/?keyword={searchterm}',
+  sync: {
+    isSyncPage($c) {
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('vod').run(),
+          $c.url().urlPart(4).equals('playback').run(),
+          $c.url().urlParam('season').boolean().run(),
+          $c.url().urlParam('content').boolean().run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return pageTitle($c)
+        .replaceRegex('\\s+第\\d+話.*$', '')
+        .replaceRegex('\\s+\\(アニメ/\\d{4}年\\).*$', '')
+        .trim()
+        .run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlParam('season').string().run();
+    },
+    getOverviewUrl($c) {
+      return $c
+        .string(`${domain}/vod/detail/?season=`)
+        .concat($c.this('sync.getIdentifier').run())
+        .run();
+    },
+    getEpisode($c) {
+      return pageTitle($c).regex('第(\\d+)話', 1).number().run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('body').uiAppend().run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('vod').run(),
+          $c.url().urlPart(4).equals('detail').run(),
+          $c.url().urlParam('season').boolean().run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return getJsonData($c).get('name').string().trim().run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlParam('season').string().run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('#detail-header').ifNotReturn().uiAfter().run();
+    },
+    getImage($c) {
+      return getJsonData($c).get('image').string().ifNotReturn().run();
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll('a[href*="content="]').run();
+    },
+    elementUrl($c) {
+      return $c.getAttribute('href').urlAbsolute(domain).run();
+    },
+    elementEp($c) {
+      return $c.text().regex('第(\\d+)話', 1).number().run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c.detectChanges($c.title().run(), $c.trigger().run()).domReady().trigger().run();
+    },
+    overviewIsReady($c) {
+      return $c.waitUntilTrue($c.querySelector('h1').boolean().run()).trigger().run();
+    },
+    listChange($c) {
+      return $c.detectChanges($c.querySelector('main').text().run(), $c.trigger().run()).run();
+    },
+  },
+};
+
+function pageTitle($c: ChibiGenerator<unknown>) {
+  return $c.title().split('|').first().trim();
+}
+
+function getJsonData($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelectorAll('[type="application/ld+json"]')
+    .arrayFind($el => $el.text().includes('TVSeries').run())
+    .ifNotReturn()
+    .text()
+    .jsonParse();
+}

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -3,6 +3,102 @@ import { PageInterface } from '../../pageInterface';
 
 const domain = 'https://tv.dmm.com';
 
+function seasonMarkerPattern() {
+  return '^(\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+)$';
+}
+
+function selectedSeasonTitlePattern() {
+  return '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+).*)$';
+}
+
+function episodePattern() {
+  return '(?:\\u7b2c|#|Episode)\\s*(\\d+)(?:\\u8a71)?';
+}
+
+function selectedSeasonLabel($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelector('#detail-header span.mr-2')
+    .text()
+    .trim()
+    .normalize()
+    .replaceRegex('([Ss]eason)\\s*(\\d+)', '$1 $2');
+}
+
+function isSelectedSeasonTitle($c: ChibiGenerator<unknown>) {
+  return $c
+    .and(
+      $c.querySelector('#detail-header span.mr-2').boolean().run(),
+      selectedSeasonLabel($c).matches(selectedSeasonTitlePattern()).run(),
+    )
+    .run();
+}
+
+function selectedSeasonTitle($c: ChibiGenerator<unknown>) {
+  return $c
+    .if(
+      isSelectedSeasonTitle($c),
+      selectedSeasonLabel($c).regex(selectedSeasonTitlePattern(), 1).run(),
+      $c.object({}).get('missing').run(),
+    )
+    .run();
+}
+
+function isSeasonMarker($c: ChibiGenerator<unknown>) {
+  return $c
+    .and(
+      $c.querySelector('#detail-header span.mr-2').boolean().run(),
+      selectedSeasonLabel($c).matches(seasonMarkerPattern()).run(),
+    )
+    .run();
+}
+
+function pageTitle($c: ChibiGenerator<unknown>) {
+  return $c.title().split('|').first().trim();
+}
+
+function isDetailUrl($c: ChibiGenerator<unknown>) {
+  return $c
+    .or(
+      $c.url().urlPart(4).equals('detail').run(),
+      $c
+        .and($c.url().urlPart(4).equals('rated').run(), $c.url().urlPart(5).equals('detail').run())
+        .run(),
+    )
+    .run();
+}
+
+function titleWithSeasonLabel($c: ChibiGenerator<unknown>) {
+  return $c
+    .if(
+      isSeasonMarker($c),
+      $c.querySelector('h1').text().trim().concat(' ').concat(selectedSeasonLabel($c).run()).run(),
+      $c.object({}).get('missing').run(),
+    )
+    .run();
+}
+
+function isAnimeDetail($c: ChibiGenerator<unknown>) {
+  return $c
+    .or(
+      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+      $c
+        .querySelectorAll('main a[href*="/vod/list/?categories="]')
+        .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
+        .boolean()
+        .run(),
+    )
+    .run();
+}
+
+function getJsonData($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelectorAll('[type="application/ld+json"]')
+    .arrayFind($el => $el.text().includes('TVSeries').run())
+    .ifNotReturn()
+    .text()
+    .jsonParse();
+}
+
 export const DMMTV: PageInterface = {
   name: 'DMM TV',
   domain,
@@ -27,7 +123,7 @@ export const DMMTV: PageInterface = {
           $c
             .and(
               $c.url().urlPart(3).equals('vod').run(),
-              $c.url().urlPart(4).equals('detail').run(),
+              isDetailUrl($c),
               $c.url().urlParam('season').boolean().run(),
               $c.url().urlParam('content').boolean().run(),
               isAnimeDetail($c),
@@ -38,9 +134,10 @@ export const DMMTV: PageInterface = {
     },
     getTitle($c) {
       return pageTitle($c)
-        .replaceRegex('\\s+(?:第\\d+話|#\\d+).*$', '')
+        .replaceRegex('\\s+(?:第\\d+話|#\\d+|Episode\\s*\\d+).*$', '')
         .replaceRegex('\\s+\\(アニメ/\\d{4}年\\).*$', '')
         .trim()
+        .ifNotReturn()
         .run();
     },
     getIdentifier($c) {
@@ -53,7 +150,7 @@ export const DMMTV: PageInterface = {
         .run();
     },
     getEpisode($c) {
-      return pageTitle($c).regex('(?:第|#)\\s*(\\d+)(?:話)?', 1).number().run();
+      return pageTitle($c).regex(episodePattern(), 1).ifNotReturn().number().run();
     },
     uiInjection($c) {
       return $c.querySelector('body').uiAppend().run();
@@ -64,7 +161,7 @@ export const DMMTV: PageInterface = {
       return $c
         .and(
           $c.url().urlPart(3).equals('vod').run(),
-          $c.url().urlPart(4).equals('detail').run(),
+          isDetailUrl($c),
           $c.url().urlParam('season').boolean().run(),
           isAnimeDetail($c),
         )
@@ -75,18 +172,10 @@ export const DMMTV: PageInterface = {
         .coalesce(
           titleWithSeasonLabel($c),
           selectedSeasonTitle($c),
-          $c
-            .querySelector('#detail-header span.mr-2')
-            .text()
-            .trim()
-            .regex(
-              '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|第\\d+期|シーズン\\s*\\d+).*)$',
-              1,
-            )
-            .run(),
           $c.querySelector('h1').text().trim().run(),
           getJsonData($c).get('name').string().trim().run(),
         )
+        .ifNotReturn()
         .run();
     },
     getIdentifier($c) {
@@ -101,13 +190,18 @@ export const DMMTV: PageInterface = {
   },
   list: {
     elementsSelector($c) {
-      return $c.querySelectorAll('a[href*="content="]').run();
+      return $c
+        .querySelectorAll(
+          'a[href*="/vod/detail/?season="][href*="content="], a[href*="/vod/rated/detail/?season="][href*="content="]',
+        )
+        .filter($el => $el.text().matches(episodePattern()).run())
+        .run();
     },
     elementUrl($c) {
       return $c.getAttribute('href').urlAbsolute(domain).run();
     },
     elementEp($c) {
-      return $c.text().regex('(?:第|#)\\s*(\\d+)(?:話)?', 1).number().run();
+      return $c.text().regex(episodePattern(), 1).ifNotReturn().number().run();
     },
   },
   lifecycle: {
@@ -118,9 +212,12 @@ export const DMMTV: PageInterface = {
       return $c
         .detectURLChanges($c.trigger().run(), { ignoreQuery: false, ignoreAnchor: true })
         .detectChanges($c.title().run(), $c.trigger().run())
-        .detectChanges($c.querySelector('#detail-header').text().run(), $c.trigger().run())
         .detectChanges(
-          $c.querySelector('main a[href*="/vod/list/?categories="]').text().run(),
+          $c.querySelectorAll('#detail-header h1, #detail-header span.mr-2').length().run(),
+          $c.trigger().run(),
+        )
+        .detectChanges(
+          $c.querySelectorAll('main a[href*="/vod/list/?categories="]').length().run(),
           $c.trigger().run(),
         )
         .domReady()
@@ -128,73 +225,31 @@ export const DMMTV: PageInterface = {
         .run();
     },
     overviewIsReady($c) {
-      return $c.waitUntilTrue($c.querySelector('h1').boolean().run()).trigger().run();
+      return $c
+        .waitUntilTrue(
+          $c
+            .and(
+              $c.querySelector('h1').boolean().run(),
+              $c.this('overview.getTitle').boolean().run(),
+            )
+            .run(),
+        )
+        .trigger()
+        .run();
     },
-    listChange($c) {
-      return $c.detectChanges($c.querySelector('main').text().run(), $c.trigger().run()).run();
+    syncIsReady($c) {
+      return $c
+        .waitUntilTrue(
+          $c
+            .and(
+              $c.url().urlParam('season').boolean().run(),
+              pageTitle($c).matches(episodePattern()).run(),
+              $c.this('sync.getTitle').boolean().run(),
+            )
+            .run(),
+        )
+        .trigger()
+        .run();
     },
   },
 };
-
-function pageTitle($c: ChibiGenerator<unknown>) {
-  return $c.title().split('|').first().trim();
-}
-
-function titleWithSeasonLabel($c: ChibiGenerator<unknown>) {
-  return $c
-    .if(
-      seasonLabel($c).boolean().run(),
-      $c.querySelector('h1').text().trim().concat(' ').concat(seasonLabel($c).run()).run(),
-      $c.object({}).get('missing').run(),
-    )
-    .run();
-}
-
-function selectedSeasonTitle($c: ChibiGenerator<unknown>) {
-  return $c
-    .querySelector('#detail-header span.mr-2')
-    .text()
-    .trim()
-    .normalize()
-    .replaceRegex('([Ss]eason)\\s*(\\d+)', '$1 $2')
-    .regex(
-      '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+).*)$',
-      1,
-    )
-    .run();
-}
-
-function seasonLabel($c: ChibiGenerator<unknown>) {
-  return $c
-    .querySelector('#detail-header span.mr-2')
-    .text()
-    .trim()
-    .normalize()
-    .replaceRegex('^([Ss]eason)\\s*(\\d+)$', '$1 $2')
-    .regex(
-      '^(\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+)$',
-      1,
-    );
-}
-
-function isAnimeDetail($c: ChibiGenerator<unknown>) {
-  return $c
-    .or(
-      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
-      $c
-        .querySelectorAll('main a[href*="/vod/list/?categories="]')
-        .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
-        .boolean()
-        .run(),
-    )
-    .run();
-}
-
-function getJsonData($c: ChibiGenerator<unknown>) {
-  return $c
-    .querySelectorAll('[type="application/ld+json"]')
-    .arrayFind($el => $el.text().includes('TVSeries').run())
-    .ifNotReturn()
-    .text()
-    .jsonParse();
-}

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -15,17 +15,29 @@ export const DMMTV: PageInterface = {
   sync: {
     isSyncPage($c) {
       return $c
-        .and(
-          $c.url().urlPart(3).equals('vod').run(),
-          $c.url().urlPart(4).equals('playback').run(),
-          $c.url().urlParam('season').boolean().run(),
-          $c.url().urlParam('content').boolean().run(),
+        .or(
+          $c
+            .and(
+              $c.url().urlPart(3).equals('vod').run(),
+              $c.url().urlPart(4).equals('playback').run(),
+              $c.url().urlParam('season').boolean().run(),
+              $c.url().urlParam('content').boolean().run(),
+            )
+            .run(),
+          $c
+            .and(
+              $c.url().urlPart(3).equals('vod').run(),
+              $c.url().urlPart(4).equals('detail').run(),
+              $c.url().urlParam('season').boolean().run(),
+              $c.url().urlParam('content').boolean().run(),
+            )
+            .run(),
         )
         .run();
     },
     getTitle($c) {
       return pageTitle($c)
-        .replaceRegex('\\s+第\\d+話.*$', '')
+        .replaceRegex('\\s+(?:第\\d+話|#\\d+).*$', '')
         .replaceRegex('\\s+\\(アニメ/\\d{4}年\\).*$', '')
         .trim()
         .run();
@@ -40,7 +52,7 @@ export const DMMTV: PageInterface = {
         .run();
     },
     getEpisode($c) {
-      return pageTitle($c).regex('第(\\d+)話', 1).number().run();
+      return pageTitle($c).regex('(?:第|#)\\s*(\\d+)(?:話)?', 1).number().run();
     },
     uiInjection($c) {
       return $c.querySelector('body').uiAppend().run();
@@ -57,7 +69,21 @@ export const DMMTV: PageInterface = {
         .run();
     },
     getTitle($c) {
-      return getJsonData($c).get('name').string().trim().run();
+      return $c
+        .coalesce(
+          $c
+            .querySelector('#detail-header span.mr-2')
+            .text()
+            .trim()
+            .regex(
+              '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|第\\d+期|シーズン\\s*\\d+).*)$',
+              1,
+            )
+            .run(),
+          $c.querySelector('h1').text().trim().run(),
+          getJsonData($c).get('name').string().trim().run(),
+        )
+        .run();
     },
     getIdentifier($c) {
       return $c.url().urlParam('season').string().run();
@@ -77,7 +103,7 @@ export const DMMTV: PageInterface = {
       return $c.getAttribute('href').urlAbsolute(domain).run();
     },
     elementEp($c) {
-      return $c.text().regex('第(\\d+)話', 1).number().run();
+      return $c.text().regex('(?:第|#)\\s*(\\d+)(?:話)?', 1).number().run();
     },
   },
   lifecycle: {
@@ -85,7 +111,12 @@ export const DMMTV: PageInterface = {
       return $c.addStyle(require('./style.less?raw').toString()).run();
     },
     ready($c) {
-      return $c.detectChanges($c.title().run(), $c.trigger().run()).domReady().trigger().run();
+      return $c
+        .detectURLChanges($c.trigger().run(), { ignoreQuery: false, ignoreAnchor: true })
+        .detectChanges($c.title().run(), $c.trigger().run())
+        .domReady()
+        .trigger()
+        .run();
     },
     overviewIsReady($c) {
       return $c.waitUntilTrue($c.querySelector('h1').boolean().run()).trigger().run();

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -11,6 +11,14 @@ function selectedSeasonTitlePattern() {
   return '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+).*)$';
 }
 
+function duplicatedDmmTitlePattern() {
+  return '^(.+?[\\uFF5E\\u301C].+?[\\uFF5E\\u301C])\\s+.+$';
+}
+
+function ignoredDmmTitlePattern() {
+  return '^(?:\\u30d3\\u30c7\\u30aa\\u306e\\u4e00\\u81f4|\\u3042\\u306a\\u305f\\u306b\\u304a\\u3059\\u3059\\u3081\\u306e\\u4f5c\\u54c1|\\u5168\\u4f5c\\u54c1\\u4e00\\u89a7|\\d{4}\\u5e74.+\\u30a2\\u30cb\\u30e1\\u914d\\u4fe1\\u30ab\\u30ec\\u30f3\\u30c0\\u30fc)$';
+}
+
 function digitEpisodePattern() {
   return '(?:\\u7b2c|#|Episode)\\s*(\\d+)(?:\\u8a71)?';
 }
@@ -25,6 +33,25 @@ function titleEpisodePattern() {
 
 function missing($c: ChibiGenerator<unknown>) {
   return $c.object({}).get('missing').run();
+}
+
+function cleanDmmTitle($c: ChibiGenerator<string>) {
+  return $c.replaceRegex(duplicatedDmmTitlePattern(), '$1').trim();
+}
+
+function hasValidDetailTitle($c: ChibiGenerator<unknown>) {
+  return $c
+    .and(
+      $c.querySelector('#detail-header h1').boolean().run(),
+      $c
+        .querySelector('#detail-header h1')
+        .text()
+        .trim()
+        .matches(ignoredDmmTitlePattern())
+        .not()
+        .run(),
+    )
+    .run();
 }
 
 function selectedSeasonLabel($c: ChibiGenerator<unknown>) {
@@ -68,6 +95,25 @@ function pageTitle($c: ChibiGenerator<unknown>) {
   return $c.title().split('|').first().trim();
 }
 
+function getJsonData($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelectorAll('[type="application/ld+json"]')
+    .arrayFind($el => $el.text().includes('TVSeries').run())
+    .ifNotReturn()
+    .text()
+    .jsonParse();
+}
+
+function detailTitle($c: ChibiGenerator<unknown>) {
+  return $c
+    .coalesce(
+      $c.fn($c.querySelector('#detail-header h1').ifNotReturn().text().trim().run()).run(),
+      $c.fn(getJsonData($c).get('name').string().trim().run()).run(),
+      $c.fn(pageTitle($c).run()).run(),
+    )
+    .ifNotReturn();
+}
+
 function isDetailUrl($c: ChibiGenerator<unknown>) {
   return $c
     .or(
@@ -83,7 +129,15 @@ function titleWithSeasonLabel($c: ChibiGenerator<unknown>) {
   return $c
     .if(
       isSeasonMarker($c),
-      $c.querySelector('h1').text().trim().concat(' ').concat(selectedSeasonLabel($c).run()).run(),
+      $c
+        .querySelector('#detail-header h1')
+        .text()
+        .trim()
+        .concat(' ')
+        .concat(selectedSeasonLabel($c).run())
+        .replaceRegex(duplicatedDmmTitlePattern(), '$1')
+        .trim()
+        .run(),
       missing($c),
     )
     .run();
@@ -118,24 +172,21 @@ function isEpisodeText($c: ChibiGenerator<string>) {
 
 function isAnimeDetail($c: ChibiGenerator<unknown>) {
   return $c
-    .or(
-      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+    .and(
+      $c.querySelector('#detail-header').boolean().run(),
+      hasValidDetailTitle($c),
       $c
-        .querySelectorAll('main a[href*="/vod/list/?categories="]')
-        .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
-        .boolean()
+        .or(
+          pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+          $c
+            .querySelectorAll('main a[href*="/vod/list/?categories="]')
+            .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
+            .boolean()
+            .run(),
+        )
         .run(),
     )
     .run();
-}
-
-function getJsonData($c: ChibiGenerator<unknown>) {
-  return $c
-    .querySelectorAll('[type="application/ld+json"]')
-    .arrayFind($el => $el.text().includes('TVSeries').run())
-    .ifNotReturn()
-    .text()
-    .jsonParse();
 }
 
 export const DMMTV: PageInterface = {
@@ -150,29 +201,16 @@ export const DMMTV: PageInterface = {
   sync: {
     isSyncPage($c) {
       return $c
-        .or(
-          $c
-            .and(
-              $c.url().urlPart(3).equals('vod').run(),
-              $c.url().urlPart(4).equals('playback').run(),
-              $c.url().urlParam('season').boolean().run(),
-              $c.url().urlParam('content').boolean().run(),
-            )
-            .run(),
-          $c
-            .and(
-              $c.url().urlPart(3).equals('vod').run(),
-              isDetailUrl($c),
-              $c.url().urlParam('season').boolean().run(),
-              $c.url().urlParam('content').boolean().run(),
-              isAnimeDetail($c),
-            )
-            .run(),
+        .and(
+          $c.url().urlPart(3).equals('vod').run(),
+          $c.url().urlPart(4).equals('playback').run(),
+          $c.url().urlParam('season').boolean().run(),
+          $c.url().urlParam('content').boolean().run(),
         )
         .run();
     },
     getTitle($c) {
-      return pageTitle($c)
+      return detailTitle($c)
         .replaceRegex(`\\s+${titleEpisodePattern()}.*$`, '')
         .replaceRegex('\\s+(?:第\\d+話|#\\d+|Episode\\s*\\d+).*$', '')
         .replaceRegex('\\s+\\(アニメ/\\d{4}年\\).*$', '')
@@ -210,10 +248,10 @@ export const DMMTV: PageInterface = {
     getTitle($c) {
       return $c
         .coalesce(
-          titleWithSeasonLabel($c),
           selectedSeasonTitle($c),
-          $c.querySelector('h1').text().trim().run(),
-          getJsonData($c).get('name').string().trim().run(),
+          titleWithSeasonLabel($c),
+          cleanDmmTitle(getJsonData($c).get('name').string().trim()).run(),
+          cleanDmmTitle($c.querySelector('#detail-header h1').text().trim()).run(),
         )
         .ifNotReturn()
         .run();
@@ -269,7 +307,9 @@ export const DMMTV: PageInterface = {
         .waitUntilTrue(
           $c
             .and(
-              $c.querySelector('h1').boolean().run(),
+              $c.querySelector('#detail-header h1').boolean().run(),
+              $c.querySelector('#detail-header').boolean().run(),
+              hasValidDetailTitle($c),
               $c.this('overview.getTitle').boolean().run(),
             )
             .run(),

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -166,10 +166,18 @@ function pageTitle($c: ChibiGenerator<unknown>) {
   return $c.title().split('|').first().trim();
 }
 
+function hasAnimeTitleMarker($c: ChibiGenerator<unknown>) {
+  return pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run();
+}
+
+function isAnimePlayback($c: ChibiGenerator<unknown>) {
+  return $c.or(isAnimeVideo($c), hasAnimeTitleMarker($c)).run();
+}
+
 function hasAnimePageMarker($c: ChibiGenerator<unknown>) {
   return $c
     .or(
-      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+      hasAnimeTitleMarker($c),
       $c
         .querySelectorAll('main a[href*="/vod/list/?categories="]')
         .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
@@ -284,7 +292,7 @@ export const DMMTV: PageInterface = {
           $c.url().urlPart(4).equals('playback').run(),
           $c.url().urlParam('season').boolean().run(),
           $c.url().urlParam('content').boolean().run(),
-          isAnimeVideo($c),
+          isAnimePlayback($c),
         )
         .run();
     },
@@ -399,7 +407,7 @@ export const DMMTV: PageInterface = {
           $c
             .and(
               $c.url().urlParam('season').boolean().run(),
-              isAnimeVideo($c),
+              isAnimePlayback($c),
               isEpisodeText(pageTitle($c)),
               $c.this('sync.getTitle').boolean().run(),
             )

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -167,7 +167,7 @@ function pageTitle($c: ChibiGenerator<unknown>) {
 }
 
 function hasAnimeTitleMarker($c: ChibiGenerator<unknown>) {
-  return pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run();
+  return pageTitle($c).matches('\\u30a2\\u30cb\\u30e1[^|)]*/\\d{4}\\u5e74').run();
 }
 
 function isAnimePlayback($c: ChibiGenerator<unknown>) {

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -31,8 +31,79 @@ function titleEpisodePattern() {
   return `(?:${digitEpisodePattern()}|${japaneseEpisodePattern()})`;
 }
 
+function animeCategoryName() {
+  return '\\u30a2\\u30cb\\u30e1';
+}
+
 function missing($c: ChibiGenerator<unknown>) {
   return $c.object({}).get('missing').run();
+}
+
+function videoCacheKey($c: ChibiGenerator<unknown>, seasonId: ChibiGenerator<string>) {
+  return $c.string('DMM TV#').concat(seasonId.run());
+}
+
+function currentVideo($c: ChibiGenerator<unknown>) {
+  return $c.getGlobalVariable(videoCacheKey($c, $c.url().urlParam('season').string()).run());
+}
+
+function requestVideo($c: ChibiGenerator<unknown>) {
+  return $c.get('data').get('data').get('video');
+}
+
+function cacheRequestVideo($c: ChibiGenerator<unknown>) {
+  return $c.if(
+    $c.url().urlParam('season').boolean().run(),
+    requestVideo($c)
+      .setGlobalVariable(videoCacheKey($c, requestVideo($c).get('id').string()).run())
+      .setGlobalVariable(videoCacheKey($c, $c.url().urlParam('season').string()).run())
+      .trigger()
+      .run(),
+    requestVideo($c)
+      .setGlobalVariable(videoCacheKey($c, requestVideo($c).get('id').string()).run())
+      .trigger()
+      .run(),
+  );
+}
+
+function hasAnimeCategory($c: ChibiGenerator<unknown>) {
+  return $c
+    .and(
+      $c.get('categories').boolean().run(),
+      $c
+        .get('categories')
+        .arrayFind($category =>
+          $c
+            .or(
+              $category.get('id').string().equals('15').run(),
+              $category.get('name').string().equals(animeCategoryName()).run(),
+            )
+            .run(),
+        )
+        .boolean()
+        .run(),
+    )
+    .run();
+}
+
+function isAnimeVideo($c: ChibiGenerator<unknown>) {
+  return currentVideo($c)
+    .ifThen($video => hasAnimeCategory($video))
+    .boolean()
+    .run();
+}
+
+function handleVideoRequest($c: ChibiGenerator<unknown>) {
+  return $c
+    .and(
+      $c.get('url').equals('https://api.tv.dmm.com/graphql').run(),
+      requestVideo($c).get('id').boolean().run(),
+      requestVideo($c)
+        .ifThen($video => hasAnimeCategory($video))
+        .boolean()
+        .run(),
+    )
+    .ifThen($request => cacheRequestVideo($request).run());
 }
 
 function cleanDmmTitle($c: ChibiGenerator<string>) {
@@ -93,6 +164,19 @@ function isSeasonMarker($c: ChibiGenerator<unknown>) {
 
 function pageTitle($c: ChibiGenerator<unknown>) {
   return $c.title().split('|').first().trim();
+}
+
+function hasAnimePageMarker($c: ChibiGenerator<unknown>) {
+  return $c
+    .or(
+      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+      $c
+        .querySelectorAll('main a[href*="/vod/list/?categories="]')
+        .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
+        .boolean()
+        .run(),
+    )
+    .run();
 }
 
 function getJsonData($c: ChibiGenerator<unknown>) {
@@ -175,16 +259,7 @@ function isAnimeDetail($c: ChibiGenerator<unknown>) {
     .and(
       $c.querySelector('#detail-header').boolean().run(),
       hasValidDetailTitle($c),
-      $c
-        .or(
-          pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
-          $c
-            .querySelectorAll('main a[href*="/vod/list/?categories="]')
-            .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
-            .boolean()
-            .run(),
-        )
-        .run(),
+      $c.or(isAnimeVideo($c), hasAnimePageMarker($c)).run(),
     )
     .run();
 }
@@ -197,6 +272,9 @@ export const DMMTV: PageInterface = {
   urls: {
     match: ['*://tv.dmm.com/vod/*'],
   },
+  features: {
+    requestProxy: true,
+  },
   search: 'https://tv.dmm.com/vod/search/?keyword={searchterm}',
   sync: {
     isSyncPage($c) {
@@ -206,6 +284,7 @@ export const DMMTV: PageInterface = {
           $c.url().urlPart(4).equals('playback').run(),
           $c.url().urlParam('season').boolean().run(),
           $c.url().urlParam('content').boolean().run(),
+          isAnimeVideo($c),
         )
         .run();
     },
@@ -294,10 +373,7 @@ export const DMMTV: PageInterface = {
           $c.querySelectorAll('#detail-header h1, #detail-header span.mr-2').length().run(),
           $c.trigger().run(),
         )
-        .detectChanges(
-          $c.querySelectorAll('main a[href*="/vod/list/?categories="]').length().run(),
-          $c.trigger().run(),
-        )
+        .requestProxy($request => handleVideoRequest($request).run())
         .domReady()
         .trigger()
         .run();
@@ -323,6 +399,7 @@ export const DMMTV: PageInterface = {
           $c
             .and(
               $c.url().urlParam('season').boolean().run(),
+              isAnimeVideo($c),
               isEpisodeText(pageTitle($c)),
               $c.this('sync.getTitle').boolean().run(),
             )

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -30,6 +30,7 @@ export const DMMTV: PageInterface = {
               $c.url().urlPart(4).equals('detail').run(),
               $c.url().urlParam('season').boolean().run(),
               $c.url().urlParam('content').boolean().run(),
+              isAnimeDetail($c),
             )
             .run(),
         )
@@ -65,12 +66,15 @@ export const DMMTV: PageInterface = {
           $c.url().urlPart(3).equals('vod').run(),
           $c.url().urlPart(4).equals('detail').run(),
           $c.url().urlParam('season').boolean().run(),
+          isAnimeDetail($c),
         )
         .run();
     },
     getTitle($c) {
       return $c
         .coalesce(
+          titleWithSeasonLabel($c),
+          selectedSeasonTitle($c),
           $c
             .querySelector('#detail-header span.mr-2')
             .text()
@@ -114,6 +118,11 @@ export const DMMTV: PageInterface = {
       return $c
         .detectURLChanges($c.trigger().run(), { ignoreQuery: false, ignoreAnchor: true })
         .detectChanges($c.title().run(), $c.trigger().run())
+        .detectChanges($c.querySelector('#detail-header').text().run(), $c.trigger().run())
+        .detectChanges(
+          $c.querySelector('main a[href*="/vod/list/?categories="]').text().run(),
+          $c.trigger().run(),
+        )
         .domReady()
         .trigger()
         .run();
@@ -129,6 +138,56 @@ export const DMMTV: PageInterface = {
 
 function pageTitle($c: ChibiGenerator<unknown>) {
   return $c.title().split('|').first().trim();
+}
+
+function titleWithSeasonLabel($c: ChibiGenerator<unknown>) {
+  return $c
+    .if(
+      seasonLabel($c).boolean().run(),
+      $c.querySelector('h1').text().trim().concat(' ').concat(seasonLabel($c).run()).run(),
+      $c.object({}).get('missing').run(),
+    )
+    .run();
+}
+
+function selectedSeasonTitle($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelector('#detail-header span.mr-2')
+    .text()
+    .trim()
+    .normalize()
+    .replaceRegex('([Ss]eason)\\s*(\\d+)', '$1 $2')
+    .regex(
+      '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+).*)$',
+      1,
+    )
+    .run();
+}
+
+function seasonLabel($c: ChibiGenerator<unknown>) {
+  return $c
+    .querySelector('#detail-header span.mr-2')
+    .text()
+    .trim()
+    .normalize()
+    .replaceRegex('^([Ss]eason)\\s*(\\d+)$', '$1 $2')
+    .regex(
+      '^(\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+)$',
+      1,
+    );
+}
+
+function isAnimeDetail($c: ChibiGenerator<unknown>) {
+  return $c
+    .or(
+      pageTitle($c).matches('\\u30a2\\u30cb\\u30e1/\\d{4}\\u5e74').run(),
+      $c
+        .querySelectorAll('main a[href*="/vod/list/?categories="]')
+        .arrayFind($el => $el.text().trim().matches('^\\u30a2\\u30cb\\u30e1$').run())
+        .boolean()
+        .run(),
+    )
+    .run();
 }
 
 function getJsonData($c: ChibiGenerator<unknown>) {

--- a/src/pages-chibi/implementations/DMMTV/main.ts
+++ b/src/pages-chibi/implementations/DMMTV/main.ts
@@ -11,8 +11,20 @@ function selectedSeasonTitlePattern() {
   return '^(.+(?:\\d+(?:st|nd|rd|th)\\s+[Ss]eason|[Ss]eason\\s*\\d+|\\u7b2c\\d+\\u671f|\\u30b7\\u30fc\\u30ba\\u30f3\\s*\\d+).*)$';
 }
 
-function episodePattern() {
+function digitEpisodePattern() {
   return '(?:\\u7b2c|#|Episode)\\s*(\\d+)(?:\\u8a71)?';
+}
+
+function japaneseEpisodePattern() {
+  return '\\u7b2c\\s*([\\u96f6\\u3007\\u4e00\\u4e8c\\u4e09\\u56db\\u4e94\\u516d\\u4e03\\u516b\\u4e5d\\u5341\\u767e\\u5343\\u4e07\\u5104\\u5146]+)\\s*\\u8a71';
+}
+
+function titleEpisodePattern() {
+  return `(?:${digitEpisodePattern()}|${japaneseEpisodePattern()})`;
+}
+
+function missing($c: ChibiGenerator<unknown>) {
+  return $c.object({}).get('missing').run();
 }
 
 function selectedSeasonLabel($c: ChibiGenerator<unknown>) {
@@ -38,7 +50,7 @@ function selectedSeasonTitle($c: ChibiGenerator<unknown>) {
     .if(
       isSelectedSeasonTitle($c),
       selectedSeasonLabel($c).regex(selectedSeasonTitlePattern(), 1).run(),
-      $c.object({}).get('missing').run(),
+      missing($c),
     )
     .run();
 }
@@ -72,8 +84,35 @@ function titleWithSeasonLabel($c: ChibiGenerator<unknown>) {
     .if(
       isSeasonMarker($c),
       $c.querySelector('h1').text().trim().concat(' ').concat(selectedSeasonLabel($c).run()).run(),
-      $c.object({}).get('missing').run(),
+      missing($c),
     )
+    .run();
+}
+
+function episodeNumber($c: ChibiGenerator<string>) {
+  return $c
+    .coalesce(
+      $c
+        .if(
+          $c.matches(digitEpisodePattern()).run(),
+          $c.regex(digitEpisodePattern(), 1).number().run(),
+          missing($c),
+        )
+        .run(),
+      $c
+        .if(
+          $c.matches(japaneseEpisodePattern()).run(),
+          $c.regex(japaneseEpisodePattern(), 1).JPtoNumeral().number().run(),
+          missing($c),
+        )
+        .run(),
+    )
+    .ifNotReturn();
+}
+
+function isEpisodeText($c: ChibiGenerator<string>) {
+  return $c
+    .or($c.matches(digitEpisodePattern()).run(), $c.matches(japaneseEpisodePattern()).run())
     .run();
 }
 
@@ -134,6 +173,7 @@ export const DMMTV: PageInterface = {
     },
     getTitle($c) {
       return pageTitle($c)
+        .replaceRegex(`\\s+${titleEpisodePattern()}.*$`, '')
         .replaceRegex('\\s+(?:第\\d+話|#\\d+|Episode\\s*\\d+).*$', '')
         .replaceRegex('\\s+\\(アニメ/\\d{4}年\\).*$', '')
         .trim()
@@ -150,7 +190,7 @@ export const DMMTV: PageInterface = {
         .run();
     },
     getEpisode($c) {
-      return pageTitle($c).regex(episodePattern(), 1).ifNotReturn().number().run();
+      return episodeNumber(pageTitle($c)).run();
     },
     uiInjection($c) {
       return $c.querySelector('body').uiAppend().run();
@@ -194,14 +234,14 @@ export const DMMTV: PageInterface = {
         .querySelectorAll(
           'a[href*="/vod/detail/?season="][href*="content="], a[href*="/vod/rated/detail/?season="][href*="content="]',
         )
-        .filter($el => $el.text().matches(episodePattern()).run())
+        .filter($el => $el.text().matches(digitEpisodePattern()).run())
         .run();
     },
     elementUrl($c) {
       return $c.getAttribute('href').urlAbsolute(domain).run();
     },
     elementEp($c) {
-      return $c.text().regex(episodePattern(), 1).ifNotReturn().number().run();
+      return $c.text().regex(digitEpisodePattern(), 1).ifNotReturn().number().run();
     },
   },
   lifecycle: {
@@ -243,7 +283,7 @@ export const DMMTV: PageInterface = {
           $c
             .and(
               $c.url().urlParam('season').boolean().run(),
-              pageTitle($c).matches(episodePattern()).run(),
+              isEpisodeText(pageTitle($c)),
               $c.this('sync.getTitle').boolean().run(),
             )
             .run(),

--- a/src/pages-chibi/implementations/DMMTV/style.less
+++ b/src/pages-chibi/implementations/DMMTV/style.less
@@ -1,0 +1,49 @@
+@import './../pages';
+
+@boxBackground: #ffffff14;
+@boxFontColor: #fff;
+@boxBorderRadius: 8px;
+@boxHighlightBackground: #ffe900;
+@boxHighlightFontColor: #111;
+@boxLabelFontColor: #b8b8b8;
+@boxOptionsBackground: #202020;
+@boxOptionsFontColor: #fff;
+@activeEp: #ffe900;
+@highlightStyle: 1;
+
+#malp {
+  width: min(720px, calc(100% - 80px));
+  margin: 14px 40px 0;
+  color: #fff;
+  font-size: 14px;
+
+  #MalData {
+    flex-wrap: wrap;
+    gap: 8px;
+
+    .malp-group {
+      min-width: 108px;
+
+      & > .malp-group-field,
+      & > .malp-group-value-section {
+        border: 1px solid #ffffff1f;
+        box-shadow: inset 0 1px 0 #ffffff12;
+        min-height: 30px;
+      }
+
+      & > .malp-group-field:hover,
+      & > .malp-group-value-section:focus-within,
+      & > .malp-group-value-section:hover {
+        background-color: @boxHighlightBackground !important;
+        color: @boxHighlightFontColor !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  #malp {
+    width: calc(100% - 32px);
+    margin-inline: 16px;
+  }
+}

--- a/src/pages-chibi/implementations/DMMTV/style.less
+++ b/src/pages-chibi/implementations/DMMTV/style.less
@@ -41,6 +41,12 @@
   }
 }
 
+#flashinfo-div,
+#flash-div-bottom,
+#flash-div-top {
+  z-index: 2147483647 !important;
+}
+
 @media (max-width: 640px) {
   #malp {
     width: calc(100% - 32px);

--- a/src/pages-chibi/implementations/DMMTV/tests.json
+++ b/src/pages-chibi/implementations/DMMTV/tests.json
@@ -1,0 +1,33 @@
+{
+  "title": "DMM TV",
+  "url": "https://tv.dmm.com/",
+  "unreliable": true,
+  "testCases": [
+    {
+      "url": "https://tv.dmm.com/vod/playback/on-demand/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
+      "expected": {
+        "sync": true,
+        "title": "水属性の魔法使い",
+        "identifier": "na2unvskytbfhm3yzkjan774t",
+        "overviewUrl": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t",
+        "episode": 1,
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t",
+      "expected": {
+        "sync": false,
+        "title": "水属性の魔法使い",
+        "identifier": "na2unvskytbfhm3yzkjan774t",
+        "image": "https://awsimgsrc.dmm.com/dig/dmmtv/video/na2unvskytbfhm3yzkjan774t/keylogo_1.png",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
+          "2": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=jahja423uz3f525uu9g9n8nce",
+          "3": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=1ptv87aer95ze5akkyadhfc7f"
+        }
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/implementations/DMMTV/tests.json
+++ b/src/pages-chibi/implementations/DMMTV/tests.json
@@ -15,6 +15,17 @@
       }
     },
     {
+      "url": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
+      "expected": {
+        "sync": true,
+        "title": "水属性の魔法使い",
+        "identifier": "na2unvskytbfhm3yzkjan774t",
+        "overviewUrl": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t",
+        "episode": 1,
+        "uiSelector": true
+      }
+    },
+    {
       "url": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t",
       "expected": {
         "sync": false,
@@ -26,6 +37,34 @@
           "1": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
           "2": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=jahja423uz3f525uu9g9n8nce",
           "3": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=1ptv87aer95ze5akkyadhfc7f"
+        }
+      }
+    },
+    {
+      "url": "https://tv.dmm.com/vod/detail/?season=97soz44nrkr9d79001ub8y53p",
+      "expected": {
+        "sync": false,
+        "title": "異世界でチート能力を手にした俺は、現実世界をも無双する ～レベルアップは人生を変えた～",
+        "identifier": "97soz44nrkr9d79001ub8y53p",
+        "image": "https://awsimgsrc.dmm.com/dig/dmmtv/video/97soz44nrkr9d79001ub8y53p/keylogo_1.png",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://tv.dmm.com/vod/detail/?season=97soz44nrkr9d79001ub8y53p&content=b2h23ap9qpn9pb5c0mveeou3x"
+        }
+      }
+    },
+    {
+      "url": "https://tv.dmm.com/vod/detail/?season=ntv80vbyn5b9222yjji2czv3m",
+      "expected": {
+        "sync": false,
+        "title": "自動販売機に生まれ変わった俺は迷宮を彷徨う 3rd season",
+        "identifier": "ntv80vbyn5b9222yjji2czv3m",
+        "image": "https://awsimgsrc.dmm.com/dig/dmmtv/video/ntv80vbyn5b9222yjji2czv3m/keylogo_1.jpg",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://tv.dmm.com/vod/detail/?season=ntv80vbyn5b9222yjji2czv3m&content=u2u04a3qk96f4c3o18t5j3hpu",
+          "2": "https://tv.dmm.com/vod/detail/?season=ntv80vbyn5b9222yjji2czv3m&content=emkcg3dwd8w1etaxwiqaoqkkm",
+          "3": "https://tv.dmm.com/vod/detail/?season=ntv80vbyn5b9222yjji2czv3m&content=ijpt8e5ktj6xvy0gwkee2g6o3"
         }
       }
     }

--- a/src/pages-chibi/implementations/DMMTV/tests.json
+++ b/src/pages-chibi/implementations/DMMTV/tests.json
@@ -17,12 +17,16 @@
     {
       "url": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
       "expected": {
-        "sync": true,
+        "sync": false,
         "title": "水属性の魔法使い",
         "identifier": "na2unvskytbfhm3yzkjan774t",
-        "overviewUrl": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t",
-        "episode": 1,
-        "uiSelector": true
+        "image": "https://awsimgsrc.dmm.com/dig/dmmtv/video/na2unvskytbfhm3yzkjan774t/keylogo_1.png",
+        "uiSelector": true,
+        "epList": {
+          "1": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=fuiad15shn3wv9dzr5o648953",
+          "2": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=jahja423uz3f525uu9g9n8nce",
+          "3": "https://tv.dmm.com/vod/detail/?season=na2unvskytbfhm3yzkjan774t&content=1ptv87aer95ze5akkyadhfc7f"
+        }
       }
     },
     {

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -104,6 +104,7 @@ import { ElfToon } from './implementations/ElfToon/main';
 import { Zoro } from './implementations/Zoro/main';
 import { TeamShadowi } from './implementations/TeamShadowi/main';
 import { TopManhua } from './implementations/TopManhua/main';
+import { DMMTV } from './implementations/DMMTV/main';
 
 export const pages: { [key: string]: PageInterface } = {
   animeav1,
@@ -210,4 +211,5 @@ export const pages: { [key: string]: PageInterface } = {
   ElfToon,
   Zoro,
   TeamShadowi,
+  DMMTV,
 };


### PR DESCRIPTION
## Summary

Adds chibi support for DMM TV (`tv.dmm.com`) anime tracking.

This integration supports:

- DMM TV playback pages:
  - `/vod/playback/on-demand/?season=...&content=...`
- DMM TV detail/overview pages:
  - `/vod/detail/?season=...`
  - `/vod/detail/?season=...&content=...`
- Title, identifier, episode, overview URL, and image extraction
- Episode list parsing from visible overview page links
- DMM-specific MALSync UI placement and styling

The implementation uses page URL parameters, document title, visible DOM, and JSON-LD metadata. It does not rely on network request interception.

## Edge Cases Covered

- DMM TV has two navigation modes: direct full-page detail loads and SPA/modal-style detail transitions from cards. The lifecycle now retriggers when the detail header/category content renders, so MALSync can initialize after DMM finishes replacing the page content.
- Anime/non-anime detection no longer depends on the numeric category id. It checks the rendered anime category text and the detail title anime/year pattern.
- Season selection is handled from DMM's visible detail header:
  - marker-only labels are combined with `h1` (`転生したらスライムだった件` + `第4期`)
  - full season titles are used directly (`... 3rd season`)
  - full-width season digits are normalized (`Season２` -> `Season 2`)
- This avoids incorrectly matching later seasons as season 1/base entries when DMM separates the base title from the selected season label.

## Testing

Ran:

```sh
npx.cmd eslint src/pages-chibi/implementations/DMMTV/main.ts --quiet
npx.cmd stylelint src/pages-chibi/implementations/DMMTV/style.less -q
npm.cmd run build:webextension:firefox
$env:FILES='[src/pages-chibi/implementations/DMMTV/tests.json,src/pages-chibi/implementations/DMMTV/main.ts]'; npm.cmd run test:headless
```

The scoped DMM headless tests passed.

Note: DMM TV can depend on Japan access/login/subscription state, so the test file is marked `unreliable`.