### PR TITLE
atsu fix on list elementEp for overview 

### DIFF
--- a/src/pages-chibi/implementations/Atsumaru/main.ts
+++ b/src/pages-chibi/implementations/Atsumaru/main.ts
@@ -150,11 +150,18 @@ export const Atsumaru: PageInterface = {
       return $c.querySelectorAll('.w-full > [class*="md:w"]').run();
     },
     elementUrl($c) {
-      return $c.find('a').getAttribute('href').urlAbsolute().run();
+      return $c.find('a').ifNotReturn().getAttribute('href').urlAbsolute().run();
     },
     elementEp($c) {
       return $c
-        .coalesce($c.target().find('.my-auto').run(), $c.target().find('.truncate').run())
+        .coalesce(
+          $c
+            .target()
+            .findAll('.my-auto')
+            .arrayFind($item => $item.text().matches('\\d+').run())
+            .run(),
+          $c.target().find('.truncate').run(),
+        )
         .text()
         .regex('\\d+')
         .number()

--- a/src/pages-chibi/implementations/Atsumaru/tests.json
+++ b/src/pages-chibi/implementations/Atsumaru/tests.json
@@ -87,6 +87,20 @@
           "256": "https://atsu.moe/read/v8Kbg/hMWr9"
         }
       }
+    },
+    {
+      "url": "https://atsu.moe/manga/1HCA",
+      "expected": {
+        "sync": false,
+        "title": "Sand Mage of the Burnt Desert",
+        "identifier": "1HCA",
+        "image": "https://atsu.moe/static/posters/TKzki9XinBVjC3GQ-large.webp",
+        "uiSelector": true,
+        "epList": {
+          "7": "https://atsu.moe/read/1HCA/qELIni",
+          "10": "https://atsu.moe/read/1HCA/PW5MQZ"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
atsu fix on list elementEp for overview that has mix both single and multi translation in their chapter instead of only one of them

<img width="914" height="1006" alt="image" src="https://github.com/user-attachments/assets/dfd0b634-9d2c-4274-bd81-e08236a94996" />

i always found out this too late...