### PR TITLE
Fix Discord Rich Presence extension detection in Chrome 148+

### DIFF
--- a/src/pages-sync/syncPage.ts
+++ b/src/pages-sync/syncPage.ts
@@ -23,7 +23,7 @@ import {
 declare let browser: any;
 
 let extensionId = 'agnaejlkbiiggajjmnpmeheigkflbnoo'; // Chrome
-if (typeof browser !== 'undefined' && typeof chrome !== 'undefined') {
+if (typeof browser !== 'undefined' && typeof browser.runtime?.getBrowserInfo === 'function') {
   extensionId = '{57081fef-67b4-482f-bcb0-69296e63ec4f}'; // Firefox
 }
 


### PR DESCRIPTION
## Summary
Fixes Discord Rich Presence registration in Chrome 148+.

Fixes #3802

## Root cause
Chrome now exposes extension APIs under `browser.*`, so the old Firefox detection also matched Chrome and used the Firefox Discord RPC extension ID.

## Fix
Detect Firefox specifically via `browser.runtime.getBrowserInfo`.

## Verification
- Built the webextension content successfully
- Ran type checking successfully
- Verified Rich Presence works live in Chrome again