### PR TITLE
test(chibi): stabilize debounce timing test

### DIFF
--- a/test/src/chibiScript/functions/asyncFunctions.test.ts
+++ b/test/src/chibiScript/functions/asyncFunctions.test.ts
@@ -379,9 +379,9 @@ describe('Async Functions', () => {
     consumer.addVariable('bar', 'first');
     await new Promise(res => setTimeout(res, 50));
     consumer.addVariable('bar', 'second');
-    await new Promise(res => setTimeout(res, 1500));
+    await waitFor(() => callCount === 1, 2500);
     consumer.addVariable('bar', 'third');
-    await new Promise(res => setTimeout(res, 1500));
+    await waitFor(() => callCount === 2, 2500);
 
     expect(callCount).to.equal(2);
     consumer.clearIntervals();
@@ -394,4 +394,22 @@ function generateAndExecute(input: ChibiJson<any>) {
   const consumer = new ChibiConsumer(script);
 
   return consumer;
+}
+
+function waitFor(condition: () => boolean, timeoutMs: number) {
+  return new Promise<void>((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (condition()) {
+        clearInterval(interval);
+        resolve();
+        return;
+      }
+
+      if (Date.now() - start >= timeoutMs) {
+        clearInterval(interval);
+        reject(new Error('Timed out waiting for condition'));
+      }
+    }, 25);
+  });
 }


### PR DESCRIPTION
﻿## Summary

Stabilizes the Chibi `debounce` timing test by waiting for the expected callback count instead of sleeping exactly on the debounce boundary.

## Problem

The test previously waited `1500ms` after changing the observed value. That is also the debounce delay.

However, the callback is triggered through `detectChanges`, which polls every `500ms` before observing the changed value and starting the debounced callback. In full-suite or CI runs, the assertion can run before the second debounced callback fires, causing:

```text
AssertionError: expected 1 to equal 2
```

This addresses the CI failure that showed up in #3840. The failing test is in the shared Chibi async test suite, so I split the fix into this separate PR to keep the DMM TV changes focused.

## Approach

Replace the fixed sleep with a small `waitFor` helper:

```ts
await waitFor(() => callCount === 2, 2500);
```

`2500ms` is only the maximum wait budget. It is chosen as a conservative upper bound for the `500ms` polling delay, `1500ms` debounce delay, and normal event-loop scheduling slack. The test continues as soon as the expected callback count is observed, so it stays responsive while still failing if the callback never fires.

A fixed longer sleep would also avoid the immediate flake, but `waitFor` keeps the assertion tied to the behavior under test instead of relying on another timing guess.

## Timing Flow

```mermaid
sequenceDiagram
    participant Test
    participant Detect as detectChanges
    participant Debounce as debounce(1500)
    participant Trigger

    Test->>Test: bar = third
    Note over Detect: polls every 500ms
    Detect->>Detect: observe changed value
    Detect->>Debounce: run debounced callback
    Note over Debounce: wait 1500ms
    Debounce->>Trigger: increment callCount
    Test->>Test: wait until callCount === 2
```

## Verification

Focused debounce test was run 5 times with temporary timing logs:

```text
Run 1: first 32ms, second 1933ms
Run 2: first 30ms, second 1936ms
Run 3: first 32ms, second 1931ms
Run 4: first 32ms, second 1926ms
Run 5: first 31ms, second 1939ms
```

Final verification after removing temporary logs:

```text
npx ts-mocha -p tsconfig.node.json test/src/**/*.test.ts --require test/_env_injection.ts --grep "debounce function" --exit
npm run test:ts:ci
```

Result:

```text
661 passing
2 pending
```
