### PR TITLE
feat(chibi): add U-NEXT support

### DIFF
--- a/src/pages-chibi/implementations/UNext/main.ts
+++ b/src/pages-chibi/implementations/UNext/main.ts
@@ -1,0 +1,236 @@
+import { PageInterface } from '../../pageInterface';
+
+type UNextContext = Parameters<PageInterface['sync']['getTitle']>[0];
+
+const digitEpisodePattern = '(?:第|#|EP)\\s*([0-9０-９]+)(?:話)?';
+const japaneseEpisodePattern = '第\\s*([零〇一二三四五六七八九十百千万億兆]+)\\s*話';
+const titleId = ($c: UNextContext) =>
+  $c
+    .coalesce(
+      $c.fn($c.url().urlParam('td').ifNotReturn().run()).run(),
+      $c.fn($c.url().urlPart(4).run()).run(),
+    )
+    .ifNotReturn();
+
+const playerHeader = ($c: UNextContext) =>
+  $c.querySelector('[data-testid="player-header-back"]').ifNotReturn().parent();
+
+const playerTitle = ($c: UNextContext) =>
+  playerHeader($c).ifNotReturn().find('h2').ifNotReturn().text().trim();
+
+const playerEpisodeTitle = ($c: UNextContext) =>
+  playerHeader($c).ifNotReturn().find('h3').ifNotReturn().text().trim();
+
+const hasPlayerEpisodeTitle = ($c: UNextContext) => playerHeader($c).find('h3').boolean();
+
+const overviewTitle = ($c: UNextContext) =>
+  $c
+    .coalesce(
+      $c
+        .fn(
+          $c
+            .querySelector('[data-testid="videoStageMain-title-text"]')
+            .ifNotReturn()
+            .text()
+            .trim()
+            .run(),
+        )
+        .run(),
+      $c
+        .fn(
+          $c
+            .querySelector('meta[property="og:title"]')
+            .ifNotReturn()
+            .getAttribute('content')
+            .replaceRegex('\\(アニメ\\s*/\\s*\\d+\\).*$', '')
+            .trim()
+            .run(),
+        )
+        .run(),
+    )
+    .run();
+
+const image = ($c: UNextContext) =>
+  $c
+    .querySelector('meta[property="og:image"]')
+    .ifNotReturn()
+    .getAttribute('content')
+    .ifNotReturn()
+    .run();
+
+const isAnimeTitlePage = ($c: UNextContext) =>
+  $c
+    .and(
+      $c.url().urlPart(3).equals('title').run(),
+      $c.url().urlPart(4).matches('^SID').run(),
+      $c.querySelector('a[href*="mgc=ANIME"]').boolean().run(),
+    )
+    .run();
+
+const hasTitleModal = ($c: UNextContext) =>
+  $c
+    .and(
+      $c.url().urlParam('td').ifNotReturn().matches('^SID').run(),
+      $c.querySelector('[data-testid="TitleModal"]').boolean().run(),
+      $c.querySelector('[data-testid="videoStageMain-title-text"]').boolean().run(),
+      $c.querySelector('[data-testid="TitleModal"] a[href*="mgc=ANIME"]').boolean().run(),
+    )
+    .run();
+
+const missing = ($c: UNextContext) => $c.object({}).get('missing').run();
+
+const episodeNumber = ($c: UNextContext, input: ReturnType<typeof playerEpisodeTitle>) =>
+  $c
+    .coalesce(
+      $c
+        .fn(
+          $c
+            .if(
+              input.normalize().matches(digitEpisodePattern).run(),
+              input.normalize().regex(digitEpisodePattern, 1).number().run(),
+              missing($c),
+            )
+            .run(),
+        )
+        .run(),
+      $c
+        .fn(
+          $c
+            .if(
+              input.matches(japaneseEpisodePattern).run(),
+              input.regex(japaneseEpisodePattern, 1).JPtoNumeral().number().run(),
+              missing($c),
+            )
+            .run(),
+        )
+        .run(),
+    )
+    .run();
+
+export const UNext: PageInterface = {
+  name: 'U-NEXT',
+  type: 'anime',
+  domain: 'https://video.unext.jp',
+  languages: ['Japanese'],
+  urls: {
+    match: ['*://video.unext.jp/*'],
+  },
+  search: 'https://video.unext.jp/freeword?query={searchterm}',
+  sync: {
+    isSyncPage($c) {
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('play').run(),
+          $c.url().urlPart(4).matches('^SID').run(),
+          $c.url().urlPart(5).matches('^ED').run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return playerTitle($c).run();
+    },
+    getIdentifier($c) {
+      return titleId($c).run();
+    },
+    getOverviewUrl($c) {
+      return $c.string('/title/<id>').replace('<id>', titleId($c).run()).urlAbsolute().run();
+    },
+    getEpisode($c) {
+      return $c
+        .if(
+          hasPlayerEpisodeTitle($c).run(),
+          episodeNumber($c, playerEpisodeTitle($c)),
+          $c.number(1).run(),
+        )
+        .run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c.or(isAnimeTitlePage($c), hasTitleModal($c)).run();
+    },
+    getTitle($c) {
+      return overviewTitle($c);
+    },
+    getIdentifier($c) {
+      return titleId($c).run();
+    },
+    uiInjection($c) {
+      return $c
+        .querySelector('[data-testid="videoStageMain-title-text"]')
+        .ifNotReturn()
+        .uiAfter()
+        .run();
+    },
+    getImage($c) {
+      return image($c);
+    },
+  },
+  list: {
+    elementsSelector($c) {
+      return $c.querySelectorAll('[data-testid="videoDetail-episodeList-episodeDetail"]').run();
+    },
+    elementUrl($c) {
+      return $c
+        .find('a[data-testid="stackedVideo-title-link"]')
+        .ifNotReturn()
+        .getAttribute('href')
+        .ifNotReturn()
+        .urlAbsolute()
+        .run();
+    },
+    elementEp($c) {
+      return episodeNumber($c as unknown as UNextContext, $c.ifNotReturn().text().trim());
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c
+        .detectURLChanges($c.trigger().run(), { ignoreQuery: false, ignoreAnchor: true })
+        .detectChanges($c.title().run(), $c.trigger().run())
+        .detectChanges(
+          $c
+            .querySelectorAll(
+              '[data-testid="videoStageMain-title-text"], [data-testid="player-header-back"]',
+            )
+            .length()
+            .run(),
+          $c.trigger().run(),
+        )
+        .detectChanges(
+          $c
+            .querySelectorAll('[data-testid="videoDetail-episodeList-episodeDetail"]')
+            .length()
+            .run(),
+          $c.trigger().run(),
+        )
+        .domReady()
+        .trigger()
+        .run();
+    },
+    overviewIsReady($c) {
+      return $c
+        .waitUntilTrue(
+          $c
+            .and(
+              $c.querySelector('[data-testid="videoStageMain-title-text"]').boolean().run(),
+              $c.this('overview.getTitle').boolean().run(),
+            )
+            .run(),
+        )
+        .trigger()
+        .run();
+    },
+    syncIsReady($c) {
+      return $c
+        .waitUntilTrue(
+          $c.and(playerTitle($c).boolean().run(), $c.this('sync.getEpisode').boolean().run()).run(),
+        )
+        .trigger()
+        .run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/UNext/main.ts
+++ b/src/pages-chibi/implementations/UNext/main.ts
@@ -79,6 +79,8 @@ const hasTitleModal = ($c: UNextContext) =>
 
 const missing = ($c: UNextContext) => $c.object({}).get('missing').run();
 
+const pageState = ($c: UNextContext) => $c.url().concat('|').concat($c.title().run());
+
 const episodeNumber = ($c: UNextContext, input: ReturnType<typeof playerEpisodeTitle>) =>
   $c
     .coalesce(
@@ -189,25 +191,9 @@ export const UNext: PageInterface = {
     },
     ready($c) {
       return $c
-        .detectURLChanges($c.trigger().run(), { ignoreQuery: false, ignoreAnchor: true })
-        .detectChanges($c.title().run(), $c.trigger().run())
-        .detectChanges(
-          $c
-            .querySelectorAll(
-              '[data-testid="videoStageMain-title-text"], [data-testid="player-header-back"]',
-            )
-            .length()
-            .run(),
-          $c.trigger().run(),
-        )
-        .detectChanges(
-          $c
-            .querySelectorAll('[data-testid="videoDetail-episodeList-episodeDetail"]')
-            .length()
-            .run(),
-          $c.trigger().run(),
-        )
+        .detectChanges(pageState($c).run(), $c.debounce(750).trigger().run())
         .domReady()
+        .debounce(750)
         .trigger()
         .run();
     },

--- a/src/pages-chibi/implementations/UNext/style.less
+++ b/src/pages-chibi/implementations/UNext/style.less
@@ -1,0 +1,21 @@
+@import './../pages';
+
+@boxBackground: #000000cc;
+@boxFontColor: #ffffff;
+@boxOptionsBackground: #202020;
+@boxOptionsFontColor: #ffffff;
+@boxHighlightBackground: #00a3ff33;
+@activeEp: #00a3ff33;
+
+#malp {
+  margin-top: 12px;
+  pointer-events: auto;
+  position: relative;
+  z-index: 2;
+}
+
+#flashinfo-div,
+#flash-div-bottom,
+#flash-div-top {
+  z-index: 2147483647 !important;
+}

--- a/src/pages-chibi/implementations/UNext/tests.json
+++ b/src/pages-chibi/implementations/UNext/tests.json
@@ -1,0 +1,36 @@
+{
+  "title": "U-NEXT",
+  "url": "https://video.unext.jp/",
+  "testCases": [
+    {
+      "url": "https://video.unext.jp/title/SID0282797",
+      "expected": {
+        "sync": false,
+        "title": "最強の職業は勇者でも賢者でもなく鑑定士（仮）らしいですよ？",
+        "identifier": "SID0282797",
+        "image": "https://imgc.nxtv.jp/img/info/tit/00282/SID0282797.png?f=jpg&q=H&p=W1024",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://video.unext.jp/genre/anime?td=SID0285884&feid=FET0012733",
+      "expected": {
+        "sync": false,
+        "title": "クラスで2番目に可愛い女の子と友だちになった",
+        "identifier": "SID0285884",
+        "image": "https://imgc.nxtv.jp/img/info/tit/00285/SID0285884.png?f=jpg&q=H&p=W1024",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://video.unext.jp/browse/feature/FET0012733?td=SID0285884",
+      "expected": {
+        "sync": false,
+        "title": "クラスで2番目に可愛い女の子と友だちになった",
+        "identifier": "SID0285884",
+        "image": "https://imgc.nxtv.jp/img/info/tit/00285/SID0285884.png?f=jpg&q=H&p=W1024",
+        "uiSelector": true
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -107,6 +107,7 @@ import { Zoro } from './implementations/Zoro/main';
 import { TeamShadowi } from './implementations/TeamShadowi/main';
 import { TopManhua } from './implementations/TopManhua/main';
 import { Tsukuyomi } from './implementations/Tsukuyomi/main';
+import { UNext } from './implementations/UNext/main';
 
 export const pages: { [key: string]: PageInterface } = {
   animeav1,
@@ -216,4 +217,5 @@ export const pages: { [key: string]: PageInterface } = {
   Zoro,
   TeamShadowi,
   Tsukuyomi,
+  UNext,
 };


### PR DESCRIPTION
﻿## Summary

Adds Chibi page support for U-NEXT (`https://video.unext.jp/`).

This includes:

- overview detection for direct title pages such as `/title/SID...`
- overview detection for SPA/modal title pages using `td=SID...`
- sync detection for player pages such as `/play/SID.../ED...`
- title, identifier, image, episode list, and player episode extraction
- guarded episode parsing for Arabic/full-width digits and Japanese numeral episode titles
- Firefox-friendly styling for the MAL-Sync UI injection

## Known limitation

Direct player URLs on U-NEXT use a stable `SID.../ED...` shape, but the player URL alone does not prove whether the title is anime. This means direct player detection may false-positive for non-anime titles if they use the same URL structure.

This is the same class of limitation as the DMM TV support in #3840. I opened #3917 to discuss a reusable core/site metadata approach for direct player pages.

## Testing

- `npx.cmd eslint src/pages-chibi/implementations/UNext/main.ts --quiet`
- scoped headless test with `FILES=["src/pages-chibi/implementations/UNext/tests.json","src/pages-chibi/implementations/UNext/main.ts","src/pages-chibi/pages.ts"] npm run test:headless`
- `npm run build:webextension:firefox`
- manually tested in Firefox with U-NEXT navigation and player pages
