### PR TITLE
Detect Firefox at compile time

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -15,6 +15,8 @@ declare global {
     html: (content: string) => string;
   };
   let api: WebExtensionType;
+  let __IS_FIREFOX__: boolean;
+
   let __MAL_SYNC_KEYS__: {
     simkl: {
       id: string;

--- a/src/pages-sync/syncPage.ts
+++ b/src/pages-sync/syncPage.ts
@@ -19,13 +19,11 @@ import {
   trackingNoteElement,
   trackingSyncButtonElement,
 } from './messageElements';
+import { isFirefox } from '../utils/general';
 
-declare let browser: any;
-
-let extensionId = 'agnaejlkbiiggajjmnpmeheigkflbnoo'; // Chrome
-if (typeof browser !== 'undefined' && typeof chrome !== 'undefined') {
-  extensionId = '{57081fef-67b4-482f-bcb0-69296e63ec4f}'; // Firefox
-}
+const extensionId = isFirefox()
+  ? '{57081fef-67b4-482f-bcb0-69296e63ec4f}'
+  : 'agnaejlkbiiggajjmnpmeheigkflbnoo';
 
 const logger = con.m('Sync', '#348fff');
 

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -871,7 +871,7 @@ export function htmlDecode(text) {
 }
 
 export function isFirefox(): boolean {
-  return Boolean(typeof browser !== 'undefined' && typeof chrome !== 'undefined');
+  return __IS_FIREFOX__;
 }
 
 export function waitForPageToBeVisible() {

--- a/webpackConfig/test.config.js
+++ b/webpackConfig/test.config.js
@@ -58,6 +58,7 @@ module.exports = {
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: false,
       __MAL_SYNC_KEYS__: JSON.stringify(getKeys()),
+      __IS_FIREFOX__: false,
     }),
   ],
 };

--- a/webpackConfig/userscript.config.js
+++ b/webpackConfig/userscript.config.js
@@ -183,6 +183,7 @@ module.exports = {
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: false,
       __MAL_SYNC_KEYS__: JSON.stringify(getKeys()),
+      __IS_FIREFOX__: false,
     }),
     new webpack.optimize.LimitChunkCountPlugin({
       maxChunks: 1,

--- a/webpackConfig/webextension.background.config.js
+++ b/webpackConfig/webextension.background.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const appTarget = process.env.APP_TARGET || 'general';
+const isFirefox = appTarget === 'firefox';
 const packageJson = require('../package.json');
 
 const { getKeys } = require('./utils/keys');
@@ -18,6 +19,7 @@ plugins = [
     __VUE_OPTIONS_API__: true,
     __VUE_PROD_DEVTOOLS__: false,
     __MAL_SYNC_KEYS__: JSON.stringify(getKeys()),
+    __IS_FIREFOX__: isFirefox,
   }),
 ]
 

--- a/webpackConfig/webextension.content.config.js
+++ b/webpackConfig/webextension.content.config.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const { VueLoaderPlugin } = require('vue-loader');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
+const isFirefox = (process.env.APP_TARGET || 'general') === 'firefox';
+
 const pages = require('./utils/pages').pages();
 const { getKeys } = require('./utils/keys');
 const { getVirtualScript } = require('./utils/general');
@@ -172,6 +174,7 @@ module.exports = {
       __VUE_OPTIONS_API__: true,
       __VUE_PROD_DEVTOOLS__: false,
       __MAL_SYNC_KEYS__: JSON.stringify(getKeys()),
+      __IS_FIREFOX__: isFirefox,
     }),
     ...(process.env.ADULT_DEV
       ? [


### PR DESCRIPTION
Fixes #3802
Reimplements #3901


As we have seperate builds for chrome and firefox, so we can destinguish it during compile time.
