### PR TITLE
feat: add ANIMO (4animo.xyz) page provider

### DIFF
--- a/pages.md
+++ b/pages.md
@@ -41,6 +41,13 @@
     <td>:x:</td>
     <td>:heavy_check_mark:</td>
   </tr><tr>
+    <td><a href="https://4animo.xyz"><img src="https://favicon.malsync.moe/?domain=https://4animo.xyz"> ANIMO</a></td>
+    <td>English</td>
+    <td>:heavy_check_mark:</td>
+    <td>:x:</td>
+    <td>:heavy_check_mark:</td>
+    <td>:x:</td>
+  </tr><tr>
     <td><a href="https://anicrush.to"><img src="https://favicon.malsync.moe/?domain=https://anicrush.to"> Anicrush</a></td>
     <td>English</td>
     <td>:heavy_check_mark:</td>

--- a/src/pages-chibi/implementations/ANIMO/main.ts
+++ b/src/pages-chibi/implementations/ANIMO/main.ts
@@ -1,0 +1,138 @@
+import { PageInterface } from '../../pageInterface';
+
+export const ANIMO: PageInterface = {
+  name: 'ANIMO',
+  type: 'anime',
+  domain: 'https://4animo.xyz',
+  languages: ['English'],
+  urls: {
+    match: [
+      // Watch pages: /watch/slug-id?ep=N
+      '*://4animo.xyz/watch/*',
+      '*://www.4animo.xyz/watch/*',
+      // Overview pages live at root: /slug-id
+      '*://4animo.xyz/*-[0-9]*',
+      '*://www.4animo.xyz/*-[0-9]*',
+    ],
+  },
+  search: 'https://4animo.xyz/search?keyword={searchtermPlus}',
+  sync: {
+    isSyncPage($c) {
+      // Watch pages: 4animo.xyz/watch/slug-id?ep=N
+      return $c.url().urlPart(3).equals('watch').run();
+    },
+    getTitle($c) {
+      return $c
+        .querySelector('meta[property="og:title"]')
+        .getAttribute('content')
+        .trim()
+        .regex('^Watch (.+) on ANIMO$')
+        .ifNotReturn($c.querySelector('h1').text().trim().run())
+        .run();
+    },
+    getIdentifier($c) {
+      // Slug format: witch-hat-atelier-15818 → identifier is "15818"
+      return $c.url().urlPart(4).split('-').last().run();
+    },
+    getOverviewUrl($c) {
+      // Overview is at root: /witch-hat-atelier-15818
+      return $c
+        .string('/')
+        .concat($c.url().urlPart(4).run())
+        .urlAbsolute()
+        .run();
+    },
+    getEpisode($c) {
+      return $c.url().urlParam('ep').number().run();
+    },
+    getImage($c) {
+      return $c
+        .querySelector('meta[property="og:image"]')
+        .getAttribute('content')
+        .ifNotReturn()
+        .run();
+    },
+    getMalUrl($c) {
+      // Prefer window.activeAnime if injected by the React client
+      return $c
+        .querySelector('meta[name="mal-id"]')
+        .ifThen($c =>
+          $c
+            .getAttribute('content')
+            .setVariable('malId')
+            .ifNotReturn()
+            .string('https://myanimelist.net/anime/')
+            .concat($c.getVariable('malId').run())
+            .return()
+            .run(),
+        )
+        .provider()
+        .equals('ANILIST')
+        .ifThen($c =>
+          $c
+            .querySelector('meta[name="anilist-id"]')
+            .ifThen($c =>
+              $c
+                .getAttribute('content')
+                .setVariable('alId')
+                .ifNotReturn()
+                .string('https://anilist.co/anime/')
+                .concat($c.getVariable('alId').run())
+                .return()
+                .run(),
+            )
+            .run(),
+        )
+        .boolean(false)
+        .run();
+    },
+  },
+  overview: {
+    isOverviewPage($c) {
+      // Overview is at root: /witch-hat-atelier-15818
+      // It's NOT a watch page and the slug ends with a numeric ID
+      return $c.url().urlPart(3).equals('watch').not().run();
+    },
+    getTitle($c) {
+      return $c.this('sync.getTitle').run();
+    },
+    getIdentifier($c) {
+      // Slug format: witch-hat-atelier-15818 → identifier is "15818"
+      return $c.url().urlPart(3).split('-').last().run();
+    },
+    getImage($c) {
+      return $c
+        .querySelector('meta[property="og:image"]')
+        .getAttribute('content')
+        .ifNotReturn()
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('main').uiPrepend().run();
+    },
+    getMalUrl($c) {
+      return $c.this('sync.getMalUrl').run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call, global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c.detectURLChanges($c.trigger().run()).domReady().trigger().run();
+    },
+    syncIsReady($c) {
+      return $c
+        .waitUntilTrue($c.querySelector('meta[property="og:title"]').boolean().run())
+        .trigger()
+        .run();
+    },
+    overviewIsReady($c) {
+      return $c
+        .waitUntilTrue($c.querySelector('meta[property="og:title"]').boolean().run())
+        .trigger()
+        .run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/ANIMO/main.ts
+++ b/src/pages-chibi/implementations/ANIMO/main.ts
@@ -52,6 +52,9 @@ export const ANIMO: PageInterface = {
         .ifNotReturn()
         .run();
     },
+    uiInjection($c) {
+      return $c.querySelector('#animo-watch-actions').uiAppend().run();
+    },
     getMalUrl($c) {
       // Prefer window.activeAnime if injected by the React client
       return $c
@@ -108,7 +111,7 @@ export const ANIMO: PageInterface = {
         .run();
     },
     uiInjection($c) {
-      return $c.querySelector('main').uiPrepend().run();
+      return $c.querySelector('#animo-header-actions').uiAppend().run();
     },
     getMalUrl($c) {
       return $c.this('sync.getMalUrl').run();
@@ -124,13 +127,13 @@ export const ANIMO: PageInterface = {
     },
     syncIsReady($c) {
       return $c
-        .waitUntilTrue($c.querySelector('meta[property="og:title"]').boolean().run())
+        .waitUntilTrue($c.querySelector('#animo-watch-actions').boolean().run())
         .trigger()
         .run();
     },
     overviewIsReady($c) {
       return $c
-        .waitUntilTrue($c.querySelector('meta[property="og:title"]').boolean().run())
+        .waitUntilTrue($c.querySelector('#animo-header-actions').boolean().run())
         .trigger()
         .run();
     },

--- a/src/pages-chibi/implementations/ANIMO/style.less
+++ b/src/pages-chibi/implementations/ANIMO/style.less
@@ -1,0 +1,6 @@
+// ANIMO-specific styles
+// Injected by the MALSync extension when on 4animo.xyz
+
+.malsync-ui {
+  margin-bottom: 1rem;
+}

--- a/src/pages-chibi/implementations/ANIMO/tests.json
+++ b/src/pages-chibi/implementations/ANIMO/tests.json
@@ -1,0 +1,27 @@
+{
+  "title": "ANIMO",
+  "url": "https://4animo.xyz",
+  "testCases": [
+    {
+      "url": "https://4animo.xyz/witch-hat-atelier-15818",
+      "expected": {
+        "sync": false,
+        "overview": true,
+        "title": "Witch Hat Atelier",
+        "identifier": "15818",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://4animo.xyz/watch/witch-hat-atelier-15818?ep=1",
+      "expected": {
+        "sync": true,
+        "title": "Witch Hat Atelier",
+        "identifier": "15818",
+        "episode": 1,
+        "overviewUrl": "https://4animo.xyz/witch-hat-atelier-15818",
+        "uiSelector": false
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -1,4 +1,5 @@
 import { PageInterface } from './pageInterface';
+import { ANIMO } from './implementations/ANIMO/main';
 
 import { animeav1 } from './implementations/animeav1/main';
 import { anicrush } from './implementations/anicrush/main';
@@ -110,6 +111,7 @@ import { Tsukuyomi } from './implementations/Tsukuyomi/main';
 import { HijalaScans } from './implementations/HijalaScans/main';
 
 export const pages: { [key: string]: PageInterface } = {
+  ANIMO,
   animeav1,
   anicrush,
   anikoto,


### PR DESCRIPTION
# Add support for ANIMO (4animo.xyz)

This PR adds support for [ANIMO](https://4animo.xyz), an English anime streaming provider. It implements a page provider using the ChibiScript DSL.

---

## Features Implemented

### URL Matching Patterns

- **Overview / Details Page** — Matches root-level slugs containing numeric IDs:
  `*://4animo.xyz/*-[0-9]*`
  *(e.g., `https://4animo.xyz/witch-hat-atelier-15818`)*

- **Watch Page** — Matches watch-prefixed paths:
  `*://4animo.xyz/watch/*`
  *(e.g., `https://4animo.xyz/watch/witch-hat-atelier-15818?ep=1`)*

### Metadata Synchronization

- **Episode Detection** — Extracts the episode number from the `?ep` query parameter on watch pages.

- **Tracker Resolution (`getMalUrl`)** — Retrieves database IDs (`myanimelist` or `anilist`) instantly from the `<meta name="mal-id">` and `<meta name="anilist-id">` HTML tags in the page header.

- **Anime ID / Identifier** — Parses the unique trailing numerical ID from the slug
  *(e.g., `15818` from `witch-hat-atelier-15818`)*.

### UI Injections

- **Overview Page** — Injects the MALSync tracking/badge UI directly into the details actions panel (`#animo-header-actions`).

- **Watch Page** — Appends the progress UI bar alongside other external links (`#animo-watch-actions`).

### Documentation

- Alphabetically added ANIMO to the supported sites list in `pages.md`.

### Testing

- Created standard unit test cases in `tests.json`.
