### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/src/_provider/Shikimori/oauth.ts
+++ b/src/_provider/Shikimori/oauth.ts
@@ -6,7 +6,6 @@ export function shikiOauth() {
       const tokens = /code=[^&]+/gi.exec(window.location.href);
       if (tokens !== null && typeof tokens[0] !== 'undefined' && tokens[0]) {
         const token = tokens[0].toString().replace(/code=/gi, '');
-        con.log('Token Found', token);
 
         const res = await authRequest({
           code: token,

--- a/src/anilist/oauth.ts
+++ b/src/anilist/oauth.ts
@@ -4,7 +4,6 @@ export function anilistOauth() {
       const tokens = /access_token=[^&]+/gi.exec(window.location.href);
       if (tokens !== null && typeof tokens[0] !== 'undefined' && tokens[0]) {
         const token = tokens[0].toString().replace(/access_token=/gi, '');
-        con.log('Token Found', token);
 
         await api.settings.set('anilistToken', token);
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `src/anilist/oauth.ts:L7`

The OAuth callback handlers extract access codes/tokens from the URL and print them with `con.log('Token Found', token)`. Browser extension console output is accessible to the user and may also be captured by debugging tools or logs. Logging OAuth credentials increases the risk of token disclosure and account compromise.

## Solution

Remove token logging entirely. If diagnostics are needed, log only a redacted marker (for example, the last 4 characters) and avoid printing secrets in any environment.

## Changes

- `src/anilist/oauth.ts` (modified)
- `src/_provider/Shikimori/oauth.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced