### PR TITLE
[BUGFIX] Fix VIZ "Continue reading" pointing to a javascript: url #2648

### DIFF
--- a/src/pages/VIZ/main.ts
+++ b/src/pages/VIZ/main.ts
@@ -49,10 +49,16 @@ export const VIZ: pageInterface = {
       return Number(episodeNumberMatches[0]);
     },
     nextEpUrl(url) {
-      return utils.absoluteLink(
-        j.$('#end_page_next_up a[data-event*="Next Chapter"]').attr('href'),
-        VIZ.domain,
-      );
+      const nextChapterHref = j.$('#end_page_next_up a[data-event*="Next Chapter"]').attr('href');
+
+      if (!nextChapterHref) return undefined;
+
+      // Viz renders the next chapter link as a `javascript:tryReadChapter(id, '/path')`
+      // pseudo-url, so extract the real path before resolving it. Otherwise the
+      // "Continue reading" button points to an unusable javascript: url (#2648).
+      const chapterPath = nextChapterHref.match(/tryReadChapter\(\d+,\s*'([^']+)'/i);
+
+      return utils.absoluteLink(chapterPath ? chapterPath[1] : nextChapterHref, VIZ.domain);
     },
   },
   overview: {


### PR DESCRIPTION
On the chapter reader, Viz exposes the "Next Chapter" link as a `javascript:tryReadChapter(id, '/path')` pseudo-url. sync.nextEpUrl passed that href straight to absoluteLink, so the resulting "Continue reading" button pointed to an unusable url such as
https://www.viz.com/javascript:tryReadChapter(8667,'/shonenjump/...%27).

Extract the real path from the wrapper before resolving it, mirroring what overview.list.elementUrl already does for the chapter list.

Fixes #2648