### PR TITLE
Update Sadscans domain to .net

### DIFF
--- a/src/pages-chibi/implementations/Sadscans/main.ts
+++ b/src/pages-chibi/implementations/Sadscans/main.ts
@@ -9,7 +9,7 @@ export const Sadscans: PageInterface = {
   languages: ['Turkish'],
   type: 'manga',
   urls: {
-    match: ['*://sadscans.net/*', '*://www.sadscans.net/*'],
+    match: ['*://*.sadscans.com/*', '*://*.sadscans.net/*'],
   },
   search: 'https://sadscans.net/series?search={searchtermPlus}',
   sync: {

--- a/src/pages-chibi/implementations/Sadscans/main.ts
+++ b/src/pages-chibi/implementations/Sadscans/main.ts
@@ -5,13 +5,13 @@ const CHAPTER_REGEX = '[Bb](?:ö|Ö)l(?:ü|Ü)m\\s*([\\d.]+)';
 
 export const Sadscans: PageInterface = {
   name: 'Sadscans',
-  domain: ['https://sadscans.com'],
+  domain: ['https://sadscans.net'],
   languages: ['Turkish'],
   type: 'manga',
   urls: {
-    match: ['*://sadscans.com/*', '*://www.sadscans.com/*'],
+    match: ['*://sadscans.net/*', '*://www.sadscans.net/*'],
   },
-  search: 'https://sadscans.com/series?search={searchtermPlus}',
+  search: 'https://sadscans.net/series?search={searchtermPlus}',
   sync: {
     isSyncPage($c) {
       return $c

--- a/src/pages-chibi/implementations/Sadscans/tests.json
+++ b/src/pages-chibi/implementations/Sadscans/tests.json
@@ -1,31 +1,31 @@
 {
   "title": "Sadscans",
-  "url": "https://sadscans.com/",
+  "url": "https://sadscans.net/",
   "testCases": [
     {
-      "url": "https://sadscans.com/reader/68c074206f92f",
+      "url": "https://sadscans.net/reader/68c074206f92f",
       "expected": {
         "sync": true,
         "title": "Blue Lock",
         "identifier": "blue-lock",
-        "overviewUrl": "https://sadscans.com/series/blue-lock",
+        "overviewUrl": "https://sadscans.net/series/blue-lock",
         "episode": 317,
-        "nextEpUrl": "https://sadscans.com/reader/68c9ac84359a1",
-        "image": "https://sadscans.com/assets/series/641882302dcfd/68c074206f92f/thumbnails/68c074207abfe.png",
+        "nextEpUrl": "https://sadscans.net/reader/68c9ac84359a1",
+        "image": "https://sadscans.net/assets/series/641882302dcfd/68c074206f92f/thumbnails/68c074207abfe.png",
         "uiSelector": false
       }
     },
     {
-      "url": "https://sadscans.com/series/blue-lock",
+      "url": "https://sadscans.net/series/blue-lock",
       "expected": {
         "sync": false,
         "title": "Blue Lock",
         "identifier": "blue-lock",
-        "image": "https://sadscans.com/assets/series/641882302dcfd/Blue Lock Oku.jpg",
+        "image": "https://sadscans.net/assets/series/641882302dcfd/Blue Lock Oku.jpg",
         "uiSelector": true,
         "epList": {
-          "318": "https://sadscans.com/reader/68c9ac84359a1",
-          "317": "https://sadscans.com/reader/68c074206f92f"
+          "318": "https://sadscans.net/reader/68c9ac84359a1",
+          "317": "https://sadscans.net/reader/68c074206f92f"
         }
       }
     }


### PR DESCRIPTION
Sadscans moved from sadscans.com to sadscans.net. The old domain now 301-redirects to the new one, so MAL-Sync stopped detecting the site.

Updated the domain, both match patterns and the search URL in the chibi implementation, and pointed the test fixtures at the new domain (same backend, paths unchanged).

Fixes #3731