### PR TITLE
Update QiScans domain to qimanga.com

### DIFF
--- a/src/pages-chibi/implementations/QiScans/main.ts
+++ b/src/pages-chibi/implementations/QiScans/main.ts
@@ -2,13 +2,13 @@ import { PageInterface } from '../../pageInterface';
 
 export const QiScans: PageInterface = {
   name: 'QiScans',
-  domain: 'https://qiscans.org',
+  domain: 'https://qimanga.com',
   languages: ['English'],
   type: 'manga',
   urls: {
-    match: ['*://qiscans.org/*', '*://qimanhwa.com/*'],
+    match: ['*://qimanga.com/*'],
   },
-  search: 'https://qiscans.org/series?searchTerm={searchtermPlus}',
+  search: 'https://qimanga.com/series?searchTerm={searchtermPlus}',
   sync: {
     isSyncPage($c) {
       return $c

--- a/src/pages-chibi/implementations/QiScans/main.ts
+++ b/src/pages-chibi/implementations/QiScans/main.ts
@@ -6,7 +6,7 @@ export const QiScans: PageInterface = {
   languages: ['English'],
   type: 'manga',
   urls: {
-    match: ['*://qimanga.com/*'],
+    match: ['*://qiscans.org/*', '*://qimanhwa.com/*', '*://qimanga.com/*'],
   },
   search: 'https://qimanga.com/series?searchTerm={searchtermPlus}',
   sync: {

--- a/src/pages-chibi/implementations/QiScans/tests.json
+++ b/src/pages-chibi/implementations/QiScans/tests.json
@@ -1,70 +1,70 @@
 {
   "title": "QiScans",
-  "url": "https://qiscans.org",
+  "url": "https://qimanga.com",
   "testCases": [
     {
-      "url": "https://qiscans.org/series/reincarnated-murim-lord/chapter-88",
+      "url": "https://qimanga.com/series/reincarnated-murim-lord/chapter-88",
       "expected": {
         "sync": true,
         "title": "Reincarnated Murim Lord",
         "identifier": "reincarnated-murim-lord",
         "image": null,
-        "overviewUrl": "https://qiscans.org/series/reincarnated-murim-lord",
+        "overviewUrl": "https://qimanga.com/series/reincarnated-murim-lord",
         "episode": 88,
-        "nextEpUrl": "https://qiscans.org/series/reincarnated-murim-lord/chapter-89",
+        "nextEpUrl": "https://qimanga.com/series/reincarnated-murim-lord/chapter-89",
         "uiSelector": false
       }
     },
     {
-      "url": "https://qiscans.org/series/i-shall-seal-the-heavens",
+      "url": "https://qimanga.com/series/i-shall-seal-the-heavens",
       "expected": {
         "sync": false,
         "title": "I Shall Seal The Heavens",
         "identifier": "i-shall-seal-the-heavens",
-        "image": "https://storage.qiscans.org/upload/2025/09/28/2f827db8-bfd3-4caf-b396-47b3cc72b489.webp",
+        "image": "https://storage.qimanhwa.com/upload/2025/09/28/2f827db8-bfd3-4caf-b396-47b3cc72b489.webp",
         "uiSelector": true,
         "epList": {
-          "19": "https://qiscans.org/series/i-shall-seal-the-heavens/chapter-19",
-          "18": "https://qiscans.org/series/i-shall-seal-the-heavens/chapter-18"
+          "19": "https://qimanga.com/series/i-shall-seal-the-heavens/chapter-19",
+          "18": "https://qimanga.com/series/i-shall-seal-the-heavens/chapter-18"
         }
       }
     },
     {
-      "url": "https://qiscans.org/series/4190634673-nano-machine",
+      "url": "https://qimanga.com/series/4190634673-nano-machine",
       "expected": {
         "sync": false,
         "title": "Nano Machine",
         "identifier": "nano-machine",
-        "image": "https://storage.qiscans.org/upload/series/4190634673-nano-machine/wp-featured-7780/featured.png",
+        "image": "https://storage.qimanhwa.com/upload/series/4190634673-nano-machine/wp-featured-7780/featured.png",
         "uiSelector": true,
         "epList": {
-          "290": "https://qiscans.org/series/4190634673-nano-machine/chapter-290",
-          "291": "https://qiscans.org/series/4190634673-nano-machine/chapter-291",
-          "292": "https://qiscans.org/series/4190634673-nano-machine/chapter-292"
+          "290": "https://qimanga.com/series/4190634673-nano-machine/chapter-290",
+          "291": "https://qimanga.com/series/4190634673-nano-machine/chapter-291",
+          "292": "https://qimanga.com/series/4190634673-nano-machine/chapter-292"
         }
       }
     },
     {
-      "url": "https://qiscans.org/series/4190634673-nano-machine/chapter-290",
+      "url": "https://qimanga.com/series/4190634673-nano-machine/chapter-290",
       "expected": {
         "sync": true,
         "title": "Nano Machine",
         "identifier": "nano-machine",
         "image": null,
-        "overviewUrl": "https://qiscans.org/series/4190634673-nano-machine",
+        "overviewUrl": "https://qimanga.com/series/4190634673-nano-machine",
         "episode": 290,
-        "nextEpUrl": "https://qiscans.org/series/4190634673-nano-machine/chapter-291",
+        "nextEpUrl": "https://qimanga.com/series/4190634673-nano-machine/chapter-291",
         "uiSelector": false
       }
     },
     {
-      "url": "https://qiscans.org/series/4190634673-nano-machine/chapter-293",
+      "url": "https://qimanga.com/series/4190634673-nano-machine/chapter-293",
       "expected": {
         "sync": true,
         "title": "Nano Machine",
         "identifier": "nano-machine",
         "image": null,
-        "overviewUrl": "https://qiscans.org/series/4190634673-nano-machine",
+        "overviewUrl": "https://qimanga.com/series/4190634673-nano-machine",
         "episode": 293,
         "nextEpUrl": null,
         "uiSelector": false


### PR DESCRIPTION
QiScans moved to qimanga.com (qiscans.org -> qimanhwa.com -> qimanga.com, all 301 redirects). Updated the domain, match pattern and search URL in the chibi implementation.

Note: the image CDN settled on a different host, so the test fixtures use qimanga.com for page URLs and storage.qimanhwa.com for images.

Fixes #3983