### PR TITLE
[BUGFIX] Update KaynScan domain to .org #3976

### DIFF
--- a/src/pages-chibi/implementations/KaynScan/main.ts
+++ b/src/pages-chibi/implementations/KaynScan/main.ts
@@ -2,13 +2,13 @@ import { PageInterface } from '../../pageInterface';
 
 export const KaynScan: PageInterface = {
   name: 'KaynScan',
-  domain: 'https://kaynscan.com',
+  domain: 'https://kaynscan.org',
   languages: ['English'],
   type: 'manga',
   urls: {
-    match: ['*://kaynscan.com/*'],
+    match: ['*://kaynscan.org/*'],
   },
-  search: 'https://kaynscan.com/series/?q={searchtermPlus}',
+  search: 'https://kaynscan.org/series/?q={searchtermPlus}',
   sync: {
     isSyncPage($c) {
       return $c

--- a/src/pages-chibi/implementations/KaynScan/tests.json
+++ b/src/pages-chibi/implementations/KaynScan/tests.json
@@ -1,25 +1,25 @@
 {
     "title": "KaynScans",
-    "url": "https://kaynscan.com",
+    "url": "https://kaynscan.org",
     "testCases": [
       {
-        "url": "https://kaynscan.com/chapter/640d715df1f-642828cb77a/",
+        "url": "https://kaynscan.org/chapter/640d715df1f-642828cb77a/",
         "expected": {
           "sync": true,
           "title": "I Was Mistaken As a Monstrous Genius Actor",
           "identifier": "640d715df1f",
-          "overviewUrl": "https://kaynscan.com/series/640d715df1f/",
+          "overviewUrl": "https://kaynscan.org/series/640d715df1f/",
           "episode": 76,
-          "nextEpUrl": "https://kaynscan.com/chapter/640d715df1f-6432a46ab94/",
+          "nextEpUrl": "https://kaynscan.org/chapter/640d715df1f-6432a46ab94/",
           "uiSelector": false,
           "epList": {
-            "77" : "https://kaynscan.com/chapter/640d715df1f-6432a46ab94/",
-            "76" : "https://kaynscan.com/chapter/640d715df1f-642828cb77a/"
+            "77" : "https://kaynscan.org/chapter/640d715df1f-6432a46ab94/",
+            "76" : "https://kaynscan.org/chapter/640d715df1f-642828cb77a/"
           }
         }
       },
       {
-        "url": "https://kaynscan.com/series/640d715df1f/",
+        "url": "https://kaynscan.org/series/640d715df1f/",
         "expected": {
           "sync": false,
           "title": "I Was Mistaken As a Monstrous Genius Actor",
@@ -27,8 +27,8 @@
           "image": "https://wsrv.nl/?url=cdn.meowing.org/uploads/J-9Kr9A9gWj",
           "uiSelector": true,
           "epList": {
-            "77" : "https://kaynscan.com/chapter/640d715df1f-6432a46ab94/",
-            "76" : "https://kaynscan.com/chapter/640d715df1f-642828cb77a/"
+            "77" : "https://kaynscan.org/chapter/640d715df1f-6432a46ab94/",
+            "76" : "https://kaynscan.org/chapter/640d715df1f-642828cb77a/"
           }
         }
       }


### PR DESCRIPTION
KaynScan moved from kaynscan.com to kaynscan.org (the old domain 301-redirects to the new one). Updated the domain, match pattern, search URL and the test fixtures. The selectors are unchanged, only the address moved.

Fixes #3976