### PR TITLE
[BUGFIX] Update KakuseiProject domain to kakuseiproject.org #3890

### DIFF
--- a/src/pages-chibi/implementations/KakuseiProject/main.ts
+++ b/src/pages-chibi/implementations/KakuseiProject/main.ts
@@ -2,14 +2,14 @@ import { PageInterface } from '../../pageInterface';
 
 export const KakuseiProject: PageInterface = {
   name: 'KakuseiProject',
-  domain: 'https://kakuseiproject.com',
+  domain: 'https://kakuseiproject.org',
   languages: ['Portuguese'],
   type: 'manga',
   urls: {
-    match: ['*://kakuseiproject.com/*'],
+    match: ['*://kakuseiproject.org/*'],
   },
   search:
-    'https://kakuseiproject.com/?s={searchtermPlus}&post_type=wp-manga&op=&author=&artist=&release=&adult=',
+    'https://kakuseiproject.org/?s={searchtermPlus}&post_type=wp-manga&op=&author=&artist=&release=&adult=',
   sync: {
     isSyncPage($c) {
       return $c

--- a/src/pages-chibi/implementations/KakuseiProject/tests.json
+++ b/src/pages-chibi/implementations/KakuseiProject/tests.json
@@ -1,30 +1,30 @@
 {
     "title": "KakuseiProject",
-    "url": "https://kakuseiproject.com",
+    "url": "https://kakuseiproject.org",
     "testCases": [
       {
-        "url": "https://kakuseiproject.com/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-51/",
+        "url": "https://kakuseiproject.org/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-51/",
         "expected": {
           "sync": true,
           "title": "Yamada-kun to Lv999 no Koi wo Suru",
           "identifier": "yamada-kun-to-lv999-no-koi-wo-suru",
-          "overviewUrl": "https://kakuseiproject.com/manga/yamada-kun-to-lv999-no-koi-wo-suru",
+          "overviewUrl": "https://kakuseiproject.org/manga/yamada-kun-to-lv999-no-koi-wo-suru",
           "episode": 51,
           "uiSelector": false,
-          "image": "https://kakuseiproject.com/wp-content/uploads/2024/03/capa-yamada.jpg"
+          "image": "https://kakuseiproject.org/wp-content/uploads/2024/03/capa-yamada.jpg"
         }
       },
       {
-        "url": "https://kakuseiproject.com/manga/yamada-kun-to-lv999-no-koi-wo-suru/",
+        "url": "https://kakuseiproject.org/manga/yamada-kun-to-lv999-no-koi-wo-suru/",
         "expected": {
           "sync": false,
           "title": "Yamada-kun to Lv999 no Koi wo Suru",
           "identifier": "yamada-kun-to-lv999-no-koi-wo-suru",
-          "image": "https://kakuseiproject.com/wp-content/uploads/2024/03/capa-yamada-193x278.jpg",
+          "image": "https://kakuseiproject.org/wp-content/uploads/2024/03/capa-yamada-193x278.jpg",
           "uiSelector": true,
           "epList": {
-            "54" : "https://kakuseiproject.com/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-54/",
-            "1": "https://kakuseiproject.com/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-1/"
+            "54" : "https://kakuseiproject.org/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-54/",
+            "1": "https://kakuseiproject.org/manga/yamada-kun-to-lv999-no-koi-wo-suru/capitulo-1/"
           }
        }
      }


### PR DESCRIPTION
kakusei Project moved from kakuseiproject.com to kakuseiproject.org. The old domain now redirects to a parked page, so the extension stopped matching. Updated the domain, match pattern, search URL and the test fixtures. Same WordPress/Madara site, just a new address.

Fixes #3890