### PR TITLE
[BUGFIX] Fix Comix cover image and search URL after site rewrite #3847

### DIFF
--- a/src/pages-chibi/implementations/Comix/main.ts
+++ b/src/pages-chibi/implementations/Comix/main.ts
@@ -9,7 +9,7 @@ export const Comix: PageInterface = {
   urls: {
     match: ['*://comix.to/*'],
   },
-  search: 'https://comix.to/browse?keyword={searchtermPlus}&order=relevance%3Adesc',
+  search: 'https://comix.to/browse?q={searchtermPlus}',
   sync: {
     isSyncPage($c) {
       return getJsonData($c).get('page').equals('chapter').run();
@@ -25,9 +25,6 @@ export const Comix: PageInterface = {
     },
     getEpisode($c) {
       return getJsonData($c).get('number').number().run();
-    },
-    getImage($c) {
-      return $c.querySelector('[itemprop="image"]').getAttribute('src').ifNotReturn().run();
     },
     getMalUrl($c) {
       return $c
@@ -59,7 +56,7 @@ export const Comix: PageInterface = {
       return getJsonData($c).get('manga_id').run();
     },
     getImage($c) {
-      return $c.querySelector('[itemprop="image"]').getAttribute('src').ifNotReturn().run();
+      return $c.querySelector('.mpage__poster img').getAttribute('src').ifNotReturn().run();
     },
     uiInjection($c) {
       return $c.querySelector('.mpage__desc-wrap').uiBefore().run();

--- a/src/pages-chibi/implementations/Comix/tests.json
+++ b/src/pages-chibi/implementations/Comix/tests.json
@@ -6,10 +6,9 @@
       "url": "https://comix.to/title/3z2z2-reincarnated-as-a-sword/2734337-chapter-84",
       "expected": {
         "sync": true,
-        "title": "Reincarnated as a Sword",
+        "title": "I Was a Sword When I Reincarnated (MangaToon)",
         "identifier": "3z2z2",
-        "image": "https://static.mfcdn.cc/a0bb/i/f/a0/68dec74db0a14.jpg",
-        "overviewUrl": "https://comix.to/title/3z2z2-reincarnated-as-a-sword",
+        "overviewUrl": "https://comix.to/title/3z2z2-i-was-a-sword-when-i-reincarnated-mangatoon",
         "episode": 84,
         "uiSelector": false
       }
@@ -18,10 +17,9 @@
       "url": "https://comix.to/title/3z2z2-reincarnated-as-a-sword/1679664-chapter-84",
       "expected": {
         "sync": true,
-        "title": "Reincarnated as a Sword",
+        "title": "I Was a Sword When I Reincarnated (MangaToon)",
         "identifier": "3z2z2",
-        "image": "https://static.mfcdn.cc/a0bb/i/f/a0/68dec74db0a14.jpg",
-        "overviewUrl": "https://comix.to/title/3z2z2-reincarnated-as-a-sword",
+        "overviewUrl": "https://comix.to/title/3z2z2-i-was-a-sword-when-i-reincarnated-mangatoon",
         "episode": 84,
         "uiSelector": false
       }
@@ -30,12 +28,12 @@
       "url": "https://comix.to/title/3z2z2-reincarnated-as-a-sword",
       "expected": {
         "sync": false,
-        "title": "Reincarnated as a Sword",
+        "title": "I Was a Sword When I Reincarnated (MangaToon)",
         "identifier": "3z2z2",
-        "image": "https://static.mfcdn.cc/a0bb/i/f/a0/68dec74db0a14.jpg",
+        "image": "https://static.comix.to/bfbe/i/f/a0/68dec74db0a14@280.jpg",
         "uiSelector": true,
         "epList": {
-          "84": "https://comix.to/title/3z2z2-reincarnated-as-a-sword/1679664-chapter-84"
+          "84": "https://comix.to/title/3z2z2-i-was-a-sword-when-i-reincarnated-mangatoon/1679664-chapter-84"
         }
       }
     }


### PR DESCRIPTION
Comix rewrote their site so the page is rendered client side now, but they still add the `#syncData` / `#mal-sync` nodes back after it loads, so detection and most of the data keep working fine. From what I could find only two things were actually broken: the cover image, because `[itemprop="image"]` is gone (the title page cover is `.mpage__poster img` now, and reader pages don't have a cover anymore so I dropped getImage there), and the search url, which went from `?keyword=...&order=...` to just `?q=...`. I also updated tests.json since the title, the url slug and the cover all changed on their end.

I checked it by loading the built page script on the live comix pages and going through everything. On a chapter page the sync works with the right title, identifier, episode and overview url, the MAL and AniList links come out correct, and the reader progress reads fine (1/33). On the title page the overview is detected, the cover shows up again, the chapter list gets picked up and the MAL box is injected like it should. Searching with `?q=` returns results, and build:chibiTypes, lint:vue, eslint and prettier all pass.

Fixes #3847
