### PR TITLE
[TASK] Add Mkissa page

### DIFF
--- a/src/pages-chibi/implementations/Mkissa/main.ts
+++ b/src/pages-chibi/implementations/Mkissa/main.ts
@@ -1,0 +1,103 @@
+import { PageInterface } from '../../pageInterface';
+
+export const Mkissa: PageInterface = {
+  name: 'Mkissa',
+  type: 'manga',
+  domain: 'https://mkissa.to',
+  languages: ['English'],
+  urls: {
+    match: ['*://mkissa.to/*'],
+  },
+  search: 'https://mkissa.to/search/manga?query={searchtermRaw}',
+  sync: {
+    isSyncPage($c) {
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('manga').run(),
+          $c.url().urlPart(5).matches('^chapter-').run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return $c
+        .querySelector('title')
+        .text()
+        .replaceRegex('\\s*[^\\w\\s]\\s*MKissa\\s*$', '')
+        .replaceRegex('\\s+Ch\\.?\\s*[\\d.]+\\s*$', '')
+        .trim()
+        .run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlPart(4).run();
+    },
+    getOverviewUrl($c) {
+      return $c.url().replaceRegex('/[^/]+$', '').run();
+    },
+    getEpisode($c) {
+      return $c.url().urlPart(5).regex('chapter-(\\d+)', 1).number().run();
+    },
+    readerConfig: [
+      {
+        current: $c =>
+          $c.querySelector('.reader__page-number-current').ifNotReturn().text().number().run(),
+        total: $c =>
+          $c.querySelector('.reader__page-number-total').ifNotReturn().text().number().run(),
+      },
+    ],
+  },
+  overview: {
+    isOverviewPage($c) {
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('manga').run(),
+          $c.url().urlPart(4).boolean().run(),
+          $c.url().urlPart(5).boolean().not().run(),
+        )
+        .run();
+    },
+    getTitle($c) {
+      return $c.querySelector('.anime-detail__title').text().trim().run();
+    },
+    getIdentifier($c) {
+      return $c.url().urlPart(4).run();
+    },
+    getImage($c) {
+      return $c
+        .querySelector('.anime-detail__banner-img')
+        .ifNotReturn()
+        .getAttribute('src')
+        .ifNotReturn()
+        .run();
+    },
+    getMalUrl($c) {
+      return $c
+        .providerUrlUtility({
+          anilistId: $c
+            .querySelector('.anime-detail__banner-img[src*="anilistcdn"]')
+            .ifNotReturn()
+            .getAttribute('src')
+            .ifNotReturn()
+            .regex('anilistcdn/media/(?:anime|manga)/[a-z]+/(\\d+)-', 1)
+            .number()
+            .ifNotReturn()
+            .run(),
+        })
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('.anime-detail__head').uiAfter().run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      return $c
+        .domReady()
+        .detectChanges($c.querySelector('title').ifNotReturn().text().run(), $c.trigger().run())
+        .trigger()
+        .run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/Mkissa/style.less
+++ b/src/pages-chibi/implementations/Mkissa/style.less
@@ -1,7 +1,10 @@
 @import './../pages';
 
-@boxBackground: #ffffff14;
-@boxHighlightBackground: #f59e0b;
-@boxHighlightFontColor: #000;
+@boxBackground: var(--color-surface-muted) !important;
+@boxFontColor: var(--color-text-secondary);
+@boxHighlightBackground: var(--color-manga-accent) !important;
+@boxHighlightFontColor: var(--color-manga-surface) !important;
 
-@activeEp: #f59e0b40;
+.box() {
+  border: 0.5px solid color-mix(in srgb, var(--color-border-subtle) 55%, transparent);
+}

--- a/src/pages-chibi/implementations/Mkissa/style.less
+++ b/src/pages-chibi/implementations/Mkissa/style.less
@@ -1,8 +1,6 @@
 @import './../pages';
 
-@boxBackground: var(--surface-2);
-@boxHighlightBackground: var(--accent);
-@boxHighlightFontColor: var(--accent-ink);
+@boxBackground: #ffffff14;
+@boxHighlightBackground: #ffffff2e;
 
-@activeEp: var(--accent) !important;
-@highlightStyle: 1;
+@activeEp: #ffffff1f;

--- a/src/pages-chibi/implementations/Mkissa/style.less
+++ b/src/pages-chibi/implementations/Mkissa/style.less
@@ -1,6 +1,7 @@
 @import './../pages';
 
 @boxBackground: #ffffff14;
-@boxHighlightBackground: #ffffff2e;
+@boxHighlightBackground: #f59e0b;
+@boxHighlightFontColor: #000;
 
-@activeEp: #ffffff1f;
+@activeEp: #f59e0b40;

--- a/src/pages-chibi/implementations/Mkissa/style.less
+++ b/src/pages-chibi/implementations/Mkissa/style.less
@@ -1,0 +1,8 @@
+@import './../pages';
+
+@boxBackground: var(--surface-2);
+@boxHighlightBackground: var(--accent);
+@boxHighlightFontColor: var(--accent-ink);
+
+@activeEp: var(--accent) !important;
+@highlightStyle: 1;

--- a/src/pages-chibi/implementations/Mkissa/tests.json
+++ b/src/pages-chibi/implementations/Mkissa/tests.json
@@ -1,0 +1,27 @@
+{
+  "title": "Mkissa",
+  "url": "https://mkissa.to",
+  "testCases": [
+    {
+      "url": "https://mkissa.to/manga/M36qvmykA5grCZsmE/chapter-0-sub",
+      "expected": {
+        "sync": true,
+        "title": "Mousou Telepathy",
+        "identifier": "M36qvmykA5grCZsmE",
+        "overviewUrl": "https://mkissa.to/manga/M36qvmykA5grCZsmE",
+        "episode": 0,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://mkissa.to/manga/M36qvmykA5grCZsmE",
+      "expected": {
+        "sync": false,
+        "title": "Mousou Telepathy",
+        "identifier": "M36qvmykA5grCZsmE",
+        "image": "https://wp.youtube-anime.com/s4.anilist.co/file/anilistcdn/media/manga/banner/97836-Avz6vkkRwkag.jpg",
+        "uiSelector": true
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/implementations/pages.less
+++ b/src/pages-chibi/implementations/pages.less
@@ -24,6 +24,14 @@
 .malp() when (@malpStyle = 0) {
   // Unstyled
 }
+
+.box() {
+  background-color: @boxBackground !important;
+  color: @boxFontColor !important;
+  border-radius: @boxBorderRadius;
+  padding: 4px 8px !important;
+}
+
 .malp() when (@malpStyle = 1) {
   #MalData {
     justify-content: flex-start !important;
@@ -42,10 +50,7 @@
       & > .malp-group-field,
       & > .malp-group-value-section {
         flex-grow: 1;
-        background-color: @boxBackground !important;
-        color: @boxFontColor !important;
-        border-radius: @boxBorderRadius;
-        padding: 4px 8px !important;
+        .box();
       }
     }
 

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -96,6 +96,7 @@ import { Kuudere } from './implementations/Kuudere/main';
 import { BigSolo } from './implementations/BigSolo/main';
 import { Plex } from './implementations/Plex/main';
 import { allManga } from './implementations/allManga/main';
+import { Mkissa } from './implementations/Mkissa/main';
 import { GaiaFlix } from './implementations/GaiaFlix/main';
 import { AniZone } from './implementations/AniZone/main';
 import { AnimeNexus } from './implementations/AnimeNexus/main';
@@ -204,6 +205,7 @@ export const pages: { [key: string]: PageInterface } = {
   BigSolo,
   Plex,
   allManga,
+  Mkissa,
   GaiaFlix,
   AniZone,
   AnimeNexus,


### PR DESCRIPTION
Adds a page for mkissa.to (manga). It runs on the same allanime backend as allManga but the frontend is a different Svelte app, so I couldn't reuse allManga's selectors and had to write new ones.

The overview page (/manga/<id>) grabs the title and cover and injects the UI. I also pull the AniList id out of the banner image so AniList users get matched directly, otherwise it falls back to searching by title. The reader (/manga/<id>/chapter-N-sub) takes the series name from the page title, the chapter number from the URL, and the page count from the reader. Deep links are behind Cloudflare and the reader is an SPA route, so it only syncs once you're moving around inside the site. I watch document.title instead of the URL so it re-syncs when you switch chapters. Left anime out for now, that player has its own Cloudflare check, can do that later.

Tested: build passes, lint and the ts tests pass. I checked the real output against actual pages from the site (an overview and a chapter), page detection, title, id, episode, overview url, image, UI injection, the AniList url and the reader progress all come out right. What I didn't do is run the extension live on the site clicking through chapters, I couldn't get a clean run past Cloudflare for that. I did confirm document.title changes on every chapter though, which is what the title-watching relies on.