### PR TITLE
Security: Browser extension built in development mode exposing full source code and source maps

### DIFF
--- a/webpackConfig/webextension.background.config.js
+++ b/webpackConfig/webextension.background.config.js
@@ -36,11 +36,11 @@ module.exports = {
       },
     ],
   },
-  devtool: 'source-map',
+  devtool: false,
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
   },
-  mode: 'development',
+  mode: 'production',
   output: {
     filename: 'background.js',
     path: path.resolve(__dirname, '..', 'dist', 'webextension'),


### PR DESCRIPTION
## Problem

The background script webpack config has `mode: 'development'` combined with `devtool: 'source-map'`.
This ships unminified source code and full source maps in the distributed browser extension.
Anyone who installs the extension can trivially read the complete source, including API keys
injected via `__MAL_SYNC_KEYS__`, internal API endpoints, OAuth flows, and logic. This makes
reverse engineering and targeted attacks straightforward.


**Severity**: `critical`
**File**: `webpackConfig/webextension.background.config.js`

## Solution

Change the mode to production and disable or restrict source maps for distribution:


## Changes

- `webpackConfig/webextension.background.config.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
