### PR TITLE
Quality: Off-by-one error in predictionXhrPOST batch loop causes data loss

### DIFF
--- a/src/background/releaseProgressUtils.ts
+++ b/src/background/releaseProgressUtils.ts
@@ -62,8 +62,8 @@ export async function predictionXhrPOST(type: string, malDATA: listElement[] | n
   if (malDATA.length <= 0) return [];
   const malDATAID = malDATA.map(el => el.apiCacheKey);
   const returnArray: xhrResponseI[] = [];
-  for (let i = 0; i <= malDATAID.length; ) {
-    const tempArray = malDATAID.slice(i, i + 49);
+  for (let i = 0; i < malDATAID.length; i += 50) {
+    const tempArray = malDATAID.slice(i, i + 50);
     const Request = {
       url: `https://api.malsync.moe/nc/mal/${type}/POST/pr`,
       data: JSON.stringify({ malids: tempArray }),
@@ -72,7 +72,6 @@ export async function predictionXhrPOST(type: string, malDATA: listElement[] | n
     await utils.wait(5000);
     const response = await api.request.xhr('POST', Request);
     returnArray.push(JSON.parse(response.responseText));
-    i += 50;
   }
 
   return returnArray.reduce((acc: xhrResponseI[], val) => acc.concat(val), []);


### PR DESCRIPTION
## Problem

The for-loop has two compounding bugs that cause every 50th element to be silently dropped and an extra empty POST request to be sent:
1. `slice(i, i + 49)` extracts 49 elements per batch, but `i += 50` advances by 50.
   This means the element at every index that is a multiple of 50 (49, 99, 149, ...) is skipped.
2. The condition `i <= malDATAID.length` uses `<=` instead of `<`, causing one extra
   iteration (and a wasted POST with an empty `malids` array) when the total count is
   an exact multiple of the step size.

For example, with 150 items: indices 0–48 are batched (49 items), index 49 is skipped, indices 50–98 are batched (49 items), index 99 is skipped, indices 100–148 are batched (49 items), index 149 is skipped, then one final empty POST is made. That's 3 dropped entries and a wasted network request.


**Severity**: `high`
**File**: `src/background/releaseProgressUtils.ts`

## Solution

Change the loop to use consistent slicing and correct bounds:


## Changes

- `src/background/releaseProgressUtils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
