### PR TITLE
[TASK] Add AniZen page

### DIFF
--- a/src/pages-chibi/implementations/AniZen/main.ts
+++ b/src/pages-chibi/implementations/AniZen/main.ts
@@ -1,0 +1,78 @@
+import { PageInterface } from '../../pageInterface';
+
+export const AniZen: PageInterface = {
+  name: 'AniZen',
+  domain: 'https://anizen.tr',
+  languages: ['English'],
+  type: 'anime',
+  urls: {
+    match: ['*://anizen.tr/*'],
+  },
+  search: 'https://anizen.tr/search?keyword={searchtermPlus}',
+  sync: {
+    isSyncPage($c) {
+      return $c
+        .and($c.url().urlPart(3).equals('watch').run(), $c.url().urlPart(4).boolean().run())
+        .run();
+    },
+    getTitle($c) {
+      return $c.querySelector('h2.title-font').text().trim().run();
+    },
+    getIdentifier($c) {
+      // The site appends a `?v=<timestamp>` cache-buster to the URL; strip it.
+      return $c.url().urlPart(4).replaceRegex('[?#].*$', '').run();
+    },
+    getOverviewUrl($c) {
+      // AniZen has no separate overview page; the watch URL is the canonical page.
+      return $c
+        .string('/watch/')
+        .concat($c.this('sync.getIdentifier').run())
+        .urlAbsolute('https://anizen.tr')
+        .run();
+    },
+    getImage($c) {
+      return $c.querySelector('[property="og:image"]').getAttribute('content').ifNotReturn().run();
+    },
+    getEpisode($c) {
+      return $c
+        .querySelector('[data-anime-id][data-episode]')
+        .getAttribute('data-episode')
+        .ifNotReturn()
+        .number()
+        .run();
+    },
+    uiInjection($c) {
+      return $c.querySelector('h2.title-font').uiAfter().run();
+    },
+  },
+  lifecycle: {
+    setup($c) {
+      return $c.addStyle(require('./style.less?raw').toString()).run();
+    },
+    ready($c) {
+      // Re-sync on episode change: the player exposes the current episode via
+      // `data-episode`, so watch both the URL and that attribute.
+      return $c
+        .detectChanges(
+          $c
+            .url()
+            .concat(
+              $c
+                .querySelector('[data-anime-id][data-episode]')
+                .getAttribute('data-episode')
+                .ifNotReturn($c.string('').run())
+                .run(),
+            )
+            .run(),
+          $c.trigger().run(),
+        )
+        .domReady()
+        .trigger()
+        .run();
+    },
+    syncIsReady($c) {
+      // Wait for the title to hydrate before syncing so the match isn't run on empty data.
+      return $c.waitUntilTrue($c.querySelector('h2.title-font').boolean().run()).trigger().run();
+    },
+  },
+};

--- a/src/pages-chibi/implementations/AniZen/style.less
+++ b/src/pages-chibi/implementations/AniZen/style.less
@@ -1,0 +1,10 @@
+@import './../pages';
+
+@boxBackground: var(--card) !important;
+@boxFontColor: var(--text);
+@boxHighlightBackground: var(--accent) !important;
+@boxHighlightFontColor: var(--bg) !important;
+
+.box() {
+  border: 0.5px solid color-mix(in srgb, var(--border-subtle) 55%, transparent);
+}

--- a/src/pages-chibi/implementations/AniZen/tests.json
+++ b/src/pages-chibi/implementations/AniZen/tests.json
@@ -1,0 +1,30 @@
+{
+  "title": "AniZen",
+  "url": "https://anizen.tr",
+  "testCases": [
+    {
+      "url": "https://anizen.tr/watch/one-piece-odmau",
+      "expected": {
+        "sync": true,
+        "title": "One Piece",
+        "identifier": "one-piece-odmau",
+        "episode": 1,
+        "image": "https://cdn.anizen.tr/poster/one-piece-odmau.jpg",
+        "overviewUrl": "https://anizen.tr/watch/one-piece-odmau",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://anizen.tr/watch/one-piece-odmau?ep=5",
+      "expected": {
+        "sync": true,
+        "title": "One Piece",
+        "identifier": "one-piece-odmau",
+        "episode": 5,
+        "image": "https://cdn.anizen.tr/poster/one-piece-odmau.jpg",
+        "overviewUrl": "https://anizen.tr/watch/one-piece-odmau",
+        "uiSelector": true
+      }
+    }
+  ]
+}

--- a/src/pages-chibi/pages.ts
+++ b/src/pages-chibi/pages.ts
@@ -107,6 +107,7 @@ import { TopManhua } from './implementations/TopManhua/main';
 import { Tsukuyomi } from './implementations/Tsukuyomi/main';
 import { HijalaScans } from './implementations/HijalaScans/main';
 import { Jellyfin } from './implementations/Jellyfin/main';
+import { AniZen } from './implementations/AniZen/main';
 
 export const pages: { [key: string]: PageInterface } = {
   animeav1,
@@ -215,4 +216,5 @@ export const pages: { [key: string]: PageInterface } = {
   Tsukuyomi,
   HijalaScans,
   Jellyfin,
+  AniZen,
 };


### PR DESCRIPTION
Site request from #3709. AniZen is a HiAnime-style site, watch-only (no separate overview page), so I did it as a sync-only page. Title, id, episode and image all come off the /watch/ page.

The box uses the site's own CSS vars instead of hardcoded colors so it blends in. There are no MAL/AniList links anywhere on the page, so it just falls back to title search. One gotcha: the site tacks a ?v= cache-buster onto the URL, so I strip that before reading the identifier.