### PR TITLE
[BUGFIX] Fix Comix progress tracking and overview UI #4034

### DIFF
--- a/src/pages-chibi/implementations/Comix/main.ts
+++ b/src/pages-chibi/implementations/Comix/main.ts
@@ -99,6 +99,12 @@ export const Comix: PageInterface = {
         .ifNotReturn($c.trigger().return().run())
         .run();
     },
+    overviewIsReady($c) {
+      return $c
+        .waitUntilTrue($c.querySelector('.mpage__desc-wrap').boolean().run())
+        .trigger()
+        .run();
+    },
     listChange($c) {
       return $c
         .detectChanges(


### PR DESCRIPTION
Two separate issues on Comix:
Chapters get marked as read instantly when the reader's progress bar is turned off. Comix removes `.rpage-progress` from the DOM in that mode, so the readerConfig ended up at 0/0 and tracking fell back to instant. Added a condition on that config plus a fallback that counts the `.rpage-page` elements instead.
The overview UI doesn't appear when logged in unless you navigate back and forward. Title and id come from the `#syncData` JSON, which is ready before the page finishes rendering, so the UI was injected too early into a missing target. It now uses the site's own `#mal-sync` slot and waits for it.

Tested on comix.to with the progress bar both on and off, progress reads correctly at every scroll position. Overview injection into `#mal-sync` also checked.
Not tested: the logged-in overview case on a real account, I only reproduced the timing with a simulated injection, so a second check there would be welcome.

Fixes #4034
