### PR TITLE
Add setting for finished release progress

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1267,6 +1267,10 @@
         "message": "Load PTW/PTR for Progress evaluation",
         "description": "In addition to CW/CR also load PTW/PTR when checking Progress"
     },
+    "settings_progressShowFinished": {
+        "message": "Show release progress for finished entries",
+        "description": "Option to show release progress bars and pills for finished anime or manga entries"
+    },
     "settings_Video_Player": {
         "message": "Video player",
         "description": "Video settings header"

--- a/assets/_locales/fr/messages.json
+++ b/assets/_locales/fr/messages.json
@@ -815,6 +815,10 @@
         "message": "Charger PTW/PTR pour l'évaluation des progrès",
         "description": "In addition to CW/CR also load PTW/PTR when checking Progress"
     },
+    "settings_progressShowFinished": {
+        "message": "Afficher la progression des sorties pour les entrées terminées",
+        "description": "Option to show release progress bars and pills for finished anime or manga entries"
+    },
     "settings_Video_Player": {
         "message": "Lecteur de vidéo",
         "description": "Video settings header"

--- a/src/_minimal/components/form/form-slider.vue
+++ b/src/_minimal/components/form/form-slider.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="slider-bar" :class="color">
+  <div class="slider-bar" :class="[color, { hasProgress: progressEp }]">
+    <MediaBar
+      v-if="progressEp"
+      class="progress-background"
+      :watched-ep="Number(modelValue)"
+      :total-ep="max"
+      :progress-ep="progressEp"
+      :progress-text="progressText"
+    />
     <vue-slider
       v-model="picked"
       :lazy="true"
@@ -21,6 +29,7 @@
 import { computed, PropType } from 'vue';
 
 import VueSlider from 'vue-slider-component/dist-css/vue-slider-component.umd.min';
+import MediaBar from '../media/media-bar.vue';
 
 const props = defineProps({
   options: {
@@ -52,6 +61,16 @@ const props = defineProps({
   disabled: {
     type: Boolean,
     default: false,
+  },
+  progressEp: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+  progressText: {
+    type: String,
+    required: false,
+    default: '',
   },
 });
 
@@ -122,6 +141,8 @@ const optionsComputed = computed(() => {
   --slider-body: var(--cl-bar-volume);
   .link();
 
+  position: relative;
+
   &:hover {
     .vue-slider-dot-handle {
       opacity: 1;
@@ -141,6 +162,25 @@ const optionsComputed = computed(() => {
 
   &.violet {
     --slider-body: var(--cl-bar-score);
+  }
+
+  &.hasProgress {
+    .progress-background {
+      position: absolute;
+      inset: 0;
+      top: 50%;
+      transform: translateY(-50%);
+      pointer-events: none;
+    }
+
+    .vue-slider-rail {
+      background-color: transparent;
+
+      .vue-slider-process {
+        background-color: transparent;
+        box-shadow: none;
+      }
+    }
   }
 }
 </style>

--- a/src/_minimal/components/overview/overview-image.vue
+++ b/src/_minimal/components/overview/overview-image.vue
@@ -91,7 +91,7 @@ const progress = computed(() => {
   if (!props.single) return false;
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
-  if (!progressEl.isAiring()) return false;
+  if (!progressEl.shouldShowProgress()) return false;
   return progressEl;
 });
 </script>

--- a/src/_minimal/components/overview/overview-image.vue
+++ b/src/_minimal/components/overview/overview-image.vue
@@ -91,7 +91,8 @@ const progress = computed(() => {
   if (!props.single) return false;
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
-  if (!progressEl.shouldShowProgress(props.single.getEpisode())) return false;
+  if (!progressEl.shouldShowProgress(props.single.getEpisode(), props.single.getTotalEpisodes()))
+    return false;
   return progressEl;
 });
 </script>

--- a/src/_minimal/components/overview/overview-image.vue
+++ b/src/_minimal/components/overview/overview-image.vue
@@ -91,7 +91,7 @@ const progress = computed(() => {
   if (!props.single) return false;
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
-  if (!progressEl.shouldShowProgress()) return false;
+  if (!progressEl.shouldShowProgress(props.single.getEpisode())) return false;
   return progressEl;
 });
 </script>

--- a/src/_minimal/components/overview/overview-update-ui.vue
+++ b/src/_minimal/components/overview/overview-update-ui.vue
@@ -288,19 +288,18 @@ const progress = computed(() => {
   if (!props.single) return false;
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
-  if (
-    !progressEl.shouldShowProgress(props.single.getEpisode(), props.single.getTotalEpisodes()) ||
-    !progressEl.progress() ||
-    !progressEl.progress()!.getCurrentEpisode()
-  )
+  if (!progressEl.getDisplayEpisode(props.single.getEpisode(), props.single.getTotalEpisodes()))
     return false;
   return progressEl;
 });
 
 const progressEpisode = computed(() => {
   if (!props.single || !progress.value) return 0;
-  if (progress.value.isFinished()) return props.single.getTotalEpisodes() || 0;
-  return progress.value.progress()!.getCurrentEpisode() || 0;
+  const displayEpisode = progress.value.getDisplayEpisode(
+    props.single.getEpisode(),
+    props.single.getTotalEpisodes(),
+  );
+  return displayEpisode || 0;
 });
 
 const progressText = computed(() => {

--- a/src/_minimal/components/overview/overview-update-ui.vue
+++ b/src/_minimal/components/overview/overview-update-ui.vue
@@ -287,7 +287,7 @@ const progress = computed(() => {
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
   if (
-    !progressEl.isAiring() ||
+    !progressEl.shouldShowProgress() ||
     !progressEl.progress() ||
     !progressEl.progress()!.getCurrentEpisode()
   )

--- a/src/_minimal/components/overview/overview-update-ui.vue
+++ b/src/_minimal/components/overview/overview-update-ui.vue
@@ -287,7 +287,7 @@ const progress = computed(() => {
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
   if (
-    !progressEl.shouldShowProgress(props.single.getEpisode()) ||
+    !progressEl.shouldShowProgress(props.single.getEpisode(), props.single.getTotalEpisodes()) ||
     !progressEl.progress() ||
     !progressEl.progress()!.getCurrentEpisode()
   )

--- a/src/_minimal/components/overview/overview-update-ui.vue
+++ b/src/_minimal/components/overview/overview-update-ui.vue
@@ -287,7 +287,7 @@ const progress = computed(() => {
   const progressEl = props.single.getProgress();
   if (!progressEl) return false;
   if (
-    !progressEl.shouldShowProgress() ||
+    !progressEl.shouldShowProgress(props.single.getEpisode()) ||
     !progressEl.progress() ||
     !progressEl.progress()!.getCurrentEpisode()
   )

--- a/src/_minimal/components/overview/overview-update-ui.vue
+++ b/src/_minimal/components/overview/overview-update-ui.vue
@@ -40,8 +40,8 @@
                   <MediaProgressPill
                     v-if="progress"
                     :watched-ep="Number(episode)"
-                    :episode="progress.progress()!.getCurrentEpisode()!"
-                    :text="progress.progress()!.getPredictionText()"
+                    :episode="progressEpisode"
+                    :text="progressText"
                   />
                 </div>
               </template>
@@ -60,6 +60,8 @@
             :disabled="!single.getTotalEpisodes()"
             :min="0"
             :max="single.getTotalEpisodes()"
+            :progress-ep="progressEpisode"
+            :progress-text="progressText"
             color="blue"
           />
         </template>
@@ -293,6 +295,17 @@ const progress = computed(() => {
   )
     return false;
   return progressEl;
+});
+
+const progressEpisode = computed(() => {
+  if (!props.single || !progress.value) return 0;
+  if (progress.value.isFinished()) return props.single.getTotalEpisodes() || 0;
+  return progress.value.progress()!.getCurrentEpisode() || 0;
+});
+
+const progressText = computed(() => {
+  if (!progress.value) return '';
+  return progress.value.progress()!.getAutoText();
 });
 
 async function update() {

--- a/src/_minimal/components/settings/settings-structure-estimation.ts
+++ b/src/_minimal/components/settings/settings-structure-estimation.ts
@@ -126,4 +126,14 @@ export const estimation: ConfObj[] = [
     },
     component: SettingsGeneral,
   },
+  {
+    key: 'progressShowFinished',
+    title: () => api.storage.lang('settings_progressShowFinished'),
+    condition: () => Boolean(Number(api.settings.get('progressInterval'))),
+    props: {
+      component: 'checkbox',
+      option: 'progressShowFinished',
+    },
+    component: SettingsGeneral,
+  },
 ];

--- a/src/_minimal/views/bookmarks.vue
+++ b/src/_minimal/views/bookmarks.vue
@@ -259,7 +259,7 @@ const formatItem = (item: listElement): bookmarkItem => {
       resItem.streamIcon = utils.favicon(resItem.streamUrl.split('/')[2]);
     }
   }
-  if (item.fn.progress?.shouldShowProgress() && item.fn.progress.progress()) {
+  if (item.fn.progress?.shouldShowProgress(item.watchedEp) && item.fn.progress.progress()) {
     resItem.progressText = item.fn.progress.progress()!.getAutoText();
     resItem.progressEp = item.fn.progress.progress()!.getCurrentEpisode() || undefined;
     resItem.progress = item.fn.progress;

--- a/src/_minimal/views/bookmarks.vue
+++ b/src/_minimal/views/bookmarks.vue
@@ -260,11 +260,10 @@ const formatItem = (item: listElement): bookmarkItem => {
     }
   }
   const progressEl = item.fn.progress;
-  if (progressEl?.shouldShowProgress(item.watchedEp, item.totalEp) && progressEl.progress()) {
+  const progressEp = progressEl ? progressEl.getDisplayEpisode(item.watchedEp, item.totalEp) : null;
+  if (progressEl && progressEp) {
     resItem.progressText = progressEl.progress()!.getAutoText();
-    resItem.progressEp = progressEl.isFinished()
-      ? item.totalEp
-      : progressEl.progress()!.getCurrentEpisode() || undefined;
+    resItem.progressEp = progressEp;
     resItem.progress = progressEl;
   }
   return resItem;

--- a/src/_minimal/views/bookmarks.vue
+++ b/src/_minimal/views/bookmarks.vue
@@ -259,7 +259,7 @@ const formatItem = (item: listElement): bookmarkItem => {
       resItem.streamIcon = utils.favicon(resItem.streamUrl.split('/')[2]);
     }
   }
-  if (item.fn.progress?.isAiring() && item.fn.progress.progress()) {
+  if (item.fn.progress?.shouldShowProgress() && item.fn.progress.progress()) {
     resItem.progressText = item.fn.progress.progress()!.getAutoText();
     resItem.progressEp = item.fn.progress.progress()!.getCurrentEpisode() || undefined;
     resItem.progress = item.fn.progress;

--- a/src/_minimal/views/bookmarks.vue
+++ b/src/_minimal/views/bookmarks.vue
@@ -259,10 +259,13 @@ const formatItem = (item: listElement): bookmarkItem => {
       resItem.streamIcon = utils.favicon(resItem.streamUrl.split('/')[2]);
     }
   }
-  if (item.fn.progress?.shouldShowProgress(item.watchedEp) && item.fn.progress.progress()) {
-    resItem.progressText = item.fn.progress.progress()!.getAutoText();
-    resItem.progressEp = item.fn.progress.progress()!.getCurrentEpisode() || undefined;
-    resItem.progress = item.fn.progress;
+  const progressEl = item.fn.progress;
+  if (progressEl?.shouldShowProgress(item.watchedEp, item.totalEp) && progressEl.progress()) {
+    resItem.progressText = progressEl.progress()!.getAutoText();
+    resItem.progressEp = progressEl.isFinished()
+      ? item.totalEp
+      : progressEl.progress()!.getCurrentEpisode() || undefined;
+    resItem.progress = progressEl;
   }
   return resItem;
 };

--- a/src/anilist/anilistClass.ts
+++ b/src/anilist/anilistClass.ts
@@ -397,14 +397,18 @@ export class AnilistClass {
             }
 
             await en.fn.initProgress();
-            if (en.fn.progress?.isAiring() && en.fn.progress.progress()?.getCurrentEpisode()) {
+            const progress = en.fn.progress;
+            const progressEpisode = progress
+              ? progress.getDisplayEpisode(en.watchedEp, en.totalEp)
+              : null;
+            if (progress && progressEpisode) {
               element
                 .parent()
                 .find('.progress')
                 .first()
                 .append(
                   j.html(
-                    ` <span class="mal-sync-ep-pre" title="${en.fn.progress.progress()!.getAutoText()}">[<span style="border-bottom: 1px dotted ${en.fn.progress.getColor()};">${en.fn.progress.progress()!.getCurrentEpisode()!}</span>]</span>`,
+                    ` <span class="mal-sync-ep-pre" title="${progress.progress()!.getAutoText()}">[<span style="border-bottom: 1px dotted ${progress.getColor()};">${progressEpisode}</span>]</span>`,
                   ),
                 );
             }

--- a/src/anilist/updateUi.vue
+++ b/src/anilist/updateUi.vue
@@ -26,9 +26,9 @@
           :additional-slot="Boolean(progress)"
           @update:value="episode = $event"
         >
-          <span v-if="progress" class="mal-sync-ep" :title="progress.progress()!.getAutoText()">
+          <span v-if="progress" class="mal-sync-ep" :title="progressText">
             [<span :style="`border-bottom: 1px dotted ${progress.getColor()};`">{{
-              progress.progress()!.getCurrentEpisode()!
+              progressEpisode
             }}</span
             >]
           </span>
@@ -99,13 +99,31 @@ export default {
     },
     progress() {
       const malObj = this.malObj as SingleAbstract | null;
-      if (
-        malObj?.getProgress()?.isAiring() &&
-        malObj.getProgress()?.progress()?.getCurrentEpisode()
-      ) {
-        return malObj.getProgress()!;
+      if (!malObj) return '';
+
+      const progress = malObj.getProgress();
+      if (progress && progress.getDisplayEpisode(malObj.getEpisode(), malObj.getTotalEpisodes())) {
+        return progress;
       }
       return '';
+    },
+    progressEpisode() {
+      const malObj = this.malObj as SingleAbstract | null;
+      if (!malObj) return 0;
+
+      const progress = malObj.getProgress();
+      const displayEpisode = progress
+        ? progress.getDisplayEpisode(malObj.getEpisode(), malObj.getTotalEpisodes())
+        : null;
+      return displayEpisode || 0;
+    },
+    progressText() {
+      const malObj = this.malObj as SingleAbstract | null;
+      if (!malObj) return '';
+
+      const progress = malObj.getProgress();
+      if (!progress || !progress.progress()) return '';
+      return progress.progress()!.getAutoText();
     },
     errorMessage() {
       return this.malObj && this.malObj.getLastError() ? this.malObj.getLastErrorMessage() : '';

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -87,6 +87,7 @@ export const settingsObj = {
     progressIntervalDefaultManga: 'en/sub',
     progressNotificationsAnime: true,
     progressNotificationsManga: true,
+    progressShowFinished: false,
     notificationsSticky: true,
 
     bookMarksList: false,

--- a/src/utils/progressRelease.ts
+++ b/src/utils/progressRelease.ts
@@ -80,14 +80,12 @@ export class ProgressRelease {
     return !this.isFinished();
   }
 
-  shouldShowProgress(watchedEp?: number | null): boolean {
+  shouldShowProgress(watchedEp?: number | null, totalEp?: number | null): boolean {
     if (this.isAiring()) return true;
     if (!api.settings.get('progressShowFinished')) return false;
 
-    const currentEpisode = this.progress()?.getCurrentEpisode();
-    if (!currentEpisode || typeof watchedEp !== 'number') return false;
-
-    return currentEpisode > watchedEp;
+    if (typeof watchedEp !== 'number' || typeof totalEp !== 'number') return false;
+    return totalEp > watchedEp;
   }
 
   getColor(): string {

--- a/src/utils/progressRelease.ts
+++ b/src/utils/progressRelease.ts
@@ -88,6 +88,14 @@ export class ProgressRelease {
     return totalEp > watchedEp;
   }
 
+  getDisplayEpisode(watchedEp?: number | null, totalEp?: number | null): number | null {
+    if (!this.shouldShowProgress(watchedEp, totalEp)) return null;
+    if (this.isFinished() && typeof totalEp === 'number' && totalEp > 0) return totalEp;
+
+    const progress = this.progress();
+    return progress ? progress.getCurrentEpisode() || null : null;
+  }
+
   getColor(): string {
     return '#f57c00';
   }

--- a/src/utils/progressRelease.ts
+++ b/src/utils/progressRelease.ts
@@ -80,8 +80,14 @@ export class ProgressRelease {
     return !this.isFinished();
   }
 
-  shouldShowProgress(): boolean {
-    return this.isAiring() || Boolean(api.settings.get('progressShowFinished'));
+  shouldShowProgress(watchedEp?: number | null): boolean {
+    if (this.isAiring()) return true;
+    if (!api.settings.get('progressShowFinished')) return false;
+
+    const currentEpisode = this.progress()?.getCurrentEpisode();
+    if (!currentEpisode || typeof watchedEp !== 'number') return false;
+
+    return currentEpisode > watchedEp;
   }
 
   getColor(): string {

--- a/src/utils/progressRelease.ts
+++ b/src/utils/progressRelease.ts
@@ -80,6 +80,10 @@ export class ProgressRelease {
     return !this.isFinished();
   }
 
+  shouldShowProgress(): boolean {
+    return this.isAiring() || Boolean(api.settings.get('progressShowFinished'));
+  }
+
   getColor(): string {
     return '#f57c00';
   }


### PR DESCRIPTION
Finished entries currently hide release progress because complete release data makes `ProgressRelease.isAiring()` false. That can be annoying when a show finishes airing while the user is behind: miniMAL falls back to only showing the watched count, so it is no longer obvious that released episodes are still unwatched.

This adds an opt-in setting for finished entries. It does not change release-progress fetching. If existing release progress data marks an entry as finished and `totalEp > watchedEp`, miniMAL uses the entry total as the release progress. For example, `6/12` shows the red availability bar up to `12`, while the blue watched bar still covers the first `6`.

Default behaviour stays unchanged.

Tested:
- `git diff --check`
- `eslint src/utils/progressRelease.ts src/_minimal/views/bookmarks.vue src/_minimal/components/overview/overview-image.vue src/_minimal/components/overview/overview-update-ui.vue` (warnings only)
- locale JSON parse
- `node webpackConfig/webextension.content.generateChibi.js`

Not tested:
- `vue-tsc --noEmit` still fails on existing `ChibiGeneratorTypes.ts` errors unrelated to this change.