### PR TITLE
Add support for Aniwave (aniwaves.ru)

### DIFF
--- a/src/pages/Aniwave/main.ts
+++ b/src/pages/Aniwave/main.ts
@@ -1,0 +1,72 @@
+import { pageInterface } from '../pageInterface';
+
+export const Aniwave: pageInterface = {
+  name: 'Aniwave',
+  domain: ['https://aniwaves.ru'],
+  languages: ['English'],
+  type: 'anime',
+  isSyncPage(url) {
+    return Boolean(utils.urlPart(url, 5));
+  },
+  isOverviewPage(url) {
+    return Boolean(utils.urlPart(url, 4)) && !utils.urlPart(url, 5);
+  },
+  sync: {
+    getTitle(url) {
+      // The site bakes the episode name into the h1 on sync pages
+      // (e.g. "One Piece Episode 2 - Enter the Great Swordsman!"),
+      // so strip that suffix to get the plain series title back.
+      return $('h1.title')
+        .first()
+        .text()
+        .trim()
+        .replace(/\s+Episode\s+\d+.*$/i, '')
+        .trim();
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 4);
+    },
+    getOverviewUrl(url) {
+      return `${Aniwave.domain}/watch/${Aniwave.sync.getIdentifier(url)}`;
+    },
+    getEpisode(url) {
+      const epPart = utils.urlPart(url, 5);
+
+      const epParts = epPart.match(/ep-(\d+)/i);
+
+      if (!epParts) return NaN;
+
+      return Number(epParts[1]);
+    },
+  },
+  overview: {
+    getTitle(url) {
+      return $('h1.title').first().text().trim();
+    },
+    getIdentifier(url) {
+      return utils.urlPart(url, 4);
+    },
+    uiSelector(selector) {
+      j.$('.info').first().prepend(j.html(selector));
+    },
+  },
+  init(page) {
+    api.storage.addStyle(
+      require('!to-string-loader!css-loader!less-loader!./style.less').toString(),
+    );
+
+    j.$(document).ready(function () {
+      utils.urlChangeDetect(() => {
+        page.reset();
+        page.handlePage();
+      });
+
+      utils.waitUntilTrue(
+        () => Boolean($('h1.title').length),
+        () => {
+          page.handlePage();
+        },
+      );
+    });
+  },
+};

--- a/src/pages/Aniwave/meta.json
+++ b/src/pages/Aniwave/meta.json
@@ -1,0 +1,6 @@
+{
+  "search": "https://aniwaves.ru/filter?keyword={searchterm}",
+  "urls": {
+    "match": ["*://*.aniwaves.ru/*"]
+  }
+}

--- a/src/pages/Aniwave/style.less
+++ b/src/pages/Aniwave/style.less
@@ -1,0 +1,13 @@
+@import './../pages';
+
+@textColor: inherit;
+
+#malp {
+  .boxStyle(#1e1e1e);
+
+  margin-bottom: 10px;
+
+  .info {
+    background-color: inherit !important;
+  }
+}

--- a/src/pages/Aniwave/tests.json
+++ b/src/pages/Aniwave/tests.json
@@ -1,0 +1,37 @@
+{
+  "title": "aniwave",
+  "url": "https://aniwaves.ru/",
+  "testCases": [
+    {
+      "url": "https://aniwaves.ru/watch/one-piece-81553/ep-2",
+      "expected": {
+        "sync": true,
+        "title": "One Piece",
+        "identifier": "one-piece-81553",
+        "overviewUrl": "https://aniwaves.ru/watch/one-piece-81553",
+        "episode": 2,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://aniwaves.ru/watch/one-piece-81553",
+      "expected": {
+        "sync": false,
+        "title": "One Piece",
+        "identifier": "one-piece-81553",
+        "uiSelector": true
+      }
+    },
+    {
+      "url": "https://aniwaves.ru/watch/one-piece-episode-of-luffy-hand-island-no-bouken-76119/ep-1",
+      "expected": {
+        "sync": true,
+        "title": "One Piece: Episode of Luffy - Adventure on Hand Island",
+        "identifier": "one-piece-episode-of-luffy-hand-island-no-bouken-76119",
+        "overviewUrl": "https://aniwaves.ru/watch/one-piece-episode-of-luffy-hand-island-no-bouken-76119",
+        "episode": 1,
+        "uiSelector": false
+      }
+    }
+  ]
+}

--- a/src/pages/pages.ts
+++ b/src/pages/pages.ts
@@ -6,6 +6,7 @@ import { Animeflv } from './Animeflv/main';
 import { Jkanime } from './Jkanime/main';
 import { Proxer } from './Proxer/main';
 import { KickAssAnime } from './KickAssAnime/main';
+import { Aniwave } from './Aniwave/main';
 import { Shinden } from './Shinden/main';
 import { Voiranime } from './Voiranime/main';
 import { VIZ } from './VIZ/main';
@@ -108,6 +109,7 @@ export const pages = {
   Proxer,
   Emby,
   KickAssAnime,
+  Aniwave,
   Shinden,
   Voiranime,
   VIZ,


### PR DESCRIPTION
## Summary
- Adds anime sync support for `aniwaves.ru` (Aniwave)
- Detects sync (episode) and overview pages from the `/watch/<slug>-<id>[/ep-<n>]` URL scheme
- Title is parsed from `h1.title`, stripping the episode suffix the site bakes in on sync pages (e.g. `"One Piece Episode 2 - ..."` → `"One Piece"`)

## Test plan
- [x] Verified `isSyncPage`/`isOverviewPage`/`getIdentifier`/`getEpisode`/`getTitle` against live pages (regular TV episode, a single-episode TV special whose title itself contains the word "Episode", and a real in-progress series)
- [x] Built the extension (`npm run build:webextension`) and loaded it unpacked in Chrome via Puppeteer; confirmed MALSync recognizes the page, extracts the correct identifier, and triggers a MAL search with the cleaned title