### PR TITLE
make comix search default to best match

### DIFF
--- a/src/pages-chibi/implementations/Comix/main.ts
+++ b/src/pages-chibi/implementations/Comix/main.ts
@@ -9,7 +9,7 @@ export const Comix: PageInterface = {
   urls: {
     match: ['*://comix.to/*'],
   },
-  search: 'https://comix.to/browse?q={searchtermPlus}',
+  search: 'https://comix.to/browse?q={searchtermPlus}&sort=relevance%3Adesc',
   sync: {
     isSyncPage($c) {
       return getJsonData($c).get('page').equals('chapter').run();


### PR DESCRIPTION
by default, comix search use 'Latest Update' which doesn't find the correct the title unless, the title just updated its new chapter
content rating default also hide some title too but i don't know if should add it or not