### PR TITLE
fix(pages-chibi): detect Jellyfin anime tagged only on the series

### DIFF
--- a/src/pages-chibi/implementations/Jellyfin/main.ts
+++ b/src/pages-chibi/implementations/Jellyfin/main.ts
@@ -30,7 +30,11 @@ type MovieMetadata = {
   Name: string;
 } & CommonMetadata;
 
-type Metadata = EpisodeMetadata | SeasonMetadata | MovieMetadata;
+type SeriesMetadata = {
+  Type: 'Series';
+} & CommonMetadata;
+
+type Metadata = EpisodeMetadata | SeasonMetadata | MovieMetadata | SeriesMetadata;
 
 type OverviewMeta = SeasonMetadata;
 
@@ -214,7 +218,11 @@ function checkMetadataRequest($c: ChibiGenerator<unknown>) {
     .getVariable('metadata')
     .get('Type')
     .equals('Movie')
-    .ifThen($c => $c.exec(handleMovie).return().run());
+    .ifThen($c => $c.exec(handleMovie).return().run())
+    .getVariable('metadata')
+    .get('Type')
+    .equals('Series')
+    .ifThen($c => $c.exec(handleSeries).return().run());
 }
 
 function isAnime($c: ChibiGenerator<unknown>) {
@@ -237,15 +245,73 @@ function isAnime($c: ChibiGenerator<unknown>) {
     .log('isAnime');
 }
 
-function handleSeason($c: ChibiGenerator<unknown>) {
+// Jellyfin only tags anime on the series, not on the episodes/seasons. Remember anime series
+// by id, and if an episode already came through waiting on it, flush it now.
+function handleSeries($c: ChibiGenerator<unknown>) {
   return isAnime($c).ifThen($c =>
-    $c.getVariable('metadata').setGlobalVariable('metadataGlobal').trigger().run(),
+    $c
+      .boolean(true)
+      .setGlobalVariable($c.getVariable<SeriesMetadata>('metadata').get('Id').run())
+      .getGlobalVariable(
+        $c
+          .string('pending_')
+          .concat($c.getVariable<SeriesMetadata>('metadata').get('Id').run())
+          .run(),
+      )
+      .ifThen($c => $c.setGlobalVariable('metadataGlobal').trigger().run())
+      .run(),
   );
 }
 
-function handleEpisode($c: ChibiGenerator<unknown>) {
-  return isAnime($c).ifThen($c =>
+// Anime if its own fields say so, or the parent series was already flagged. Otherwise stash
+// it until the series response shows up.
+function handleSeason($c: ChibiGenerator<unknown>) {
+  return $c.if(
+    $c
+      .or(
+        isAnime($c).run(),
+        $c
+          .getGlobalVariable($c.getVariable<SeasonMetadata>('metadata').get('SeriesId').run())
+          .boolean()
+          .run(),
+      )
+      .run(),
     $c.getVariable('metadata').setGlobalVariable('metadataGlobal').trigger().run(),
+    $c
+      .getVariable('metadata')
+      .setGlobalVariable(
+        $c
+          .string('pending_')
+          .concat($c.getVariable<SeasonMetadata>('metadata').get('SeriesId').run())
+          .run(),
+      )
+      .run(),
+  );
+}
+
+// Anime if its own fields say so, or the parent series was already flagged. Otherwise stash
+// it until the series response shows up.
+function handleEpisode($c: ChibiGenerator<unknown>) {
+  return $c.if(
+    $c
+      .or(
+        isAnime($c).run(),
+        $c
+          .getGlobalVariable($c.getVariable<EpisodeMetadata>('metadata').get('SeriesId').run())
+          .boolean()
+          .run(),
+      )
+      .run(),
+    $c.getVariable('metadata').setGlobalVariable('metadataGlobal').trigger().run(),
+    $c
+      .getVariable('metadata')
+      .setGlobalVariable(
+        $c
+          .string('pending_')
+          .concat($c.getVariable<EpisodeMetadata>('metadata').get('SeriesId').run())
+          .run(),
+      )
+      .run(),
   );
 }
 

--- a/src/pages-chibi/implementations/Jellyfin/main.ts
+++ b/src/pages-chibi/implementations/Jellyfin/main.ts
@@ -49,7 +49,7 @@ export const Jellyfin: PageInterface = {
   domain: 'https://jellyfin.org',
   languages: ['Many'],
   type: 'anime',
-  minimumVersion: '0.12.3',
+  minimumVersion: '0.12.5',
   urls: {
     match: [],
   },
@@ -245,13 +245,13 @@ function isAnime($c: ChibiGenerator<unknown>) {
     .log('isAnime');
 }
 
-// Jellyfin only tags anime on the series, not on the episodes/seasons. Remember anime series
-// by id, and if an episode already came through waiting on it, flush it now.
+// Jellyfin only tags anime on the series, not on the episodes/seasons. Persist the anime flag
+// by series id, and flush any episode that already came through waiting on it.
 function handleSeries($c: ChibiGenerator<unknown>) {
   return isAnime($c).ifThen($c =>
     $c
       .boolean(true)
-      .setGlobalVariable($c.getVariable<SeriesMetadata>('metadata').get('Id').run())
+      .setPersistentVariable($c.getVariable<SeriesMetadata>('metadata').get('Id').run())
       .getGlobalVariable(
         $c
           .string('pending_')
@@ -271,7 +271,7 @@ function handleSeason($c: ChibiGenerator<unknown>) {
       .or(
         isAnime($c).run(),
         $c
-          .getGlobalVariable($c.getVariable<SeasonMetadata>('metadata').get('SeriesId').run())
+          .getPersistentVariable($c.getVariable<SeasonMetadata>('metadata').get('SeriesId').run())
           .boolean()
           .run(),
       )
@@ -297,7 +297,7 @@ function handleEpisode($c: ChibiGenerator<unknown>) {
       .or(
         isAnime($c).run(),
         $c
-          .getGlobalVariable($c.getVariable<EpisodeMetadata>('metadata').get('SeriesId').run())
+          .getPersistentVariable($c.getVariable<EpisodeMetadata>('metadata').get('SeriesId').run())
           .boolean()
           .run(),
       )


### PR DESCRIPTION
Jellyfin only puts the `Anime` genre/tag on the Series item. The episodes and seasons come back with empty genres and tags, so `isAnime` always returned false on an episode and nothing ever synced.

On top of that, `checkMetadataRequest` was ignoring the Series response entirely (it only handled Season/Episode/Movie), so the one response that actually had the anime marker was being thrown away.

Fix:
- Handle the `Series` type and remember whether a series is anime, keyed by its id.
- Episodes and seasons now count as anime if their own fields say so, or if their parent series was already flagged. If the series hasn't been seen yet, the episode gets stashed and flushed once the series response comes in.

So it works regardless of which response arrives first (e.g. landing directly on an episode). Movies are unchanged, and no new chibi features are used.

Tested against a real server (ZENSHU) where the anime tag is only on the series.