### PR TITLE
[BUGFIX] Ignore key auto-repeat in the shortcut listener

### DIFF
--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -271,8 +271,6 @@ export function shortcutListener(callback) {
     function keyEvent(e) {
 
       e = e || event;
-      // Holding a key fires repeated keydowns, each re-triggering the shortcut
-      // (e.g. toggling the correction popup open/closed).
       if (e.repeat) return;
       const key = e.which || e.keyCode;
       keyMap[key] = e.type === 'keydown';

--- a/src/utils/player.ts
+++ b/src/utils/player.ts
@@ -271,6 +271,9 @@ export function shortcutListener(callback) {
     function keyEvent(e) {
 
       e = e || event;
+      // Holding a key fires repeated keydowns, each re-triggering the shortcut
+      // (e.g. toggling the correction popup open/closed).
+      if (e.repeat) return;
       const key = e.which || e.keyCode;
       keyMap[key] = e.type === 'keydown';
 


### PR DESCRIPTION
Fixes #3978

Managed to reproduce this on anime-sama.to. Despite the issue title it's not a focus problem there is no blur handler anywhere that could close the popup.

What's actually going on: `openCorrection()` is a toggle (calling it while the popup is open closes it), and the shortcut listener fires on every keydown, including the auto-repeated ones you get from holding a key. Hold the shortcut slightly too long and the popup opens and closes in a loop, which looks exactly like the "flashes then disappears" from the video.

Single-key shortcuts (the default is just `C`) have a sneakier variant: `checkShortcut` requires the exact number of pressed keys, so while a modifier is held the shortcut doesn't fire at all. It ends up firing on the modifier's keyup instead, and the first auto-repeat of the key you're still holding closes the popup right after it opened.

One physical press should mean one trigger, so the fix is to ignore keydown events that have `e.repeat` set.

Chrome (unpacked build) on anime-sama.to. Before: holding the shortcut key toggled the popup open/closed repeatedly (5 keydowns = 5 toggles). After: it opens once and stays open. A deliberate second press still closes it, that behavior is unchanged. Not tested on Firefox.
