### PR TITLE
Add CSV import and JSON export functionality

### DIFF
--- a/src/_minimal/components/settings/settings-local-sync-export.vue
+++ b/src/_minimal/components/settings/settings-local-sync-export.vue
@@ -14,7 +14,10 @@
 </template>
 
 <script lang="ts" setup>
-import { exportData, importData } from '../../../_provider/Local/import';
+import { exportData, importData, convertCsvToImportFormat } from '../../../_provider/Local/import';
+import { status, type contentType } from '../../../_provider/definitions';
+import { getListbyType } from '../../../_provider/listFactory';
+import { getSyncMode, getProviderOption } from '../../../_provider/helper';
 import FormButton from '../form/form-button.vue';
 import SettingsGeneral from './settings-general.vue';
 import SettingsLocalSyncFileUpload from './settings-local-sync-file-upload.vue';
@@ -27,16 +30,19 @@ defineProps({
 });
 
 async function exportFallbackSync() {
-  const exportObj = await exportData();
+  const exportObj = {
+    ...(await exportData()),
+    ...(await exportRemoteSync()),
+  };
   con.log('Export', exportObj);
 
-  const encodedUri = `data:text/csv;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
+  const encodedUri = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
   try {
     const link = document.createElement('a');
     link.setAttribute('href', encodedUri);
     link.setAttribute(
       'download',
-      `malsync_${new Date().toJSON().slice(0, 10).replace(/-/g, '/')}.txt`,
+      `malsync_${new Date().toJSON().slice(0, 10).replace(/-/g, '/')}.json`,
     );
     document.body.appendChild(link);
 
@@ -47,8 +53,73 @@ async function exportFallbackSync() {
   utils.flashm('File exported');
 }
 
-function importFallbackSync(filecontent) {
+async function exportRemoteSync() {
+  const exportObj = {};
+  const listTypes = getActiveListTypes();
+
+  for (const listType of listTypes) {
+    const listProvider = getListbyType(getSyncMode(listType), [status.All, listType]);
+    const list = await listProvider.getCompleteList();
+
+    for (const entry of list) {
+      if (!entry.url) continue;
+      if (String(entry.uid).startsWith('local://')) continue;
+
+      exportObj[entry.url] = {
+        name: entry.title.replace(/^\[L\]\s*/, ''),
+        progress: entry.watchedEp ?? 0,
+        volumeprogress: entry.readVol ?? 0,
+        score: entry.score ?? 0,
+        status: entry.status ?? 0,
+        tags: entry.tags ?? '',
+        image: entry.image ?? '',
+        sUrl: entry.fn?.continueUrl?.() || entry.url,
+        source: listProvider.name,
+        type: listType,
+      };
+    }
+  }
+
+  return exportObj;
+}
+
+function getActiveListTypes(): contentType[] {
+  const primaryMode = api.settings.get('syncMode');
+  const secondaryMode = api.settings.get('syncModeSimkl');
+  const types = new Set<contentType>();
+
+  const primaryProvider = getProviderOption(primaryMode);
+  if (primaryProvider.anime) types.add('anime');
+  if (primaryProvider.manga) types.add('manga');
+
+  const secondaryProvider = getProviderOption(secondaryMode);
+  if (!primaryProvider.anime && secondaryProvider.anime) types.add('anime');
+  if ((!primaryProvider.manga || api.settings.get('splitTracking')) && secondaryProvider.manga) {
+    types.add('manga');
+  }
+
+  return Array.from(types);
+}
+
+async function importFallbackSync(filecontent: string) {
   con.log('Import FallbackSync', filecontent);
+  
+  const trimmed = filecontent.trim();
+  const isJson = trimmed.startsWith('{');
+  const isCsv = trimmed.includes('Title') || trimmed.includes('title') || trimmed.includes('TITLE');
+
+  con.log('Detection - isJson:', isJson, 'isCsv:', isCsv);
+
+  if (isJson) {
+    importJson(filecontent);
+  } else if (isCsv) {
+    await importCsv(filecontent);
+  } else {
+    alert('File format not recognized. Please use JSON export or CSV with Title column.');
+  }
+}
+
+function importJson(filecontent: string) {
   try {
     const iData = JSON.parse(filecontent);
     con.log('data', iData);
@@ -67,7 +138,7 @@ function importFallbackSync(filecontent) {
     importData(iData)
       .then(() => {
         utils.flashm('File imported');
-        alert('File imported');
+        alert('File imported successfully');
       })
       .catch(e => {
         if (e.message) {
@@ -76,8 +147,24 @@ function importFallbackSync(filecontent) {
         throw e;
       });
   } catch (e) {
-    alert('File has wrong formating');
-    con.error('File has wrong formating:', e);
+    alert('JSON file has wrong format');
+    con.error('JSON file has wrong format:', e);
+  }
+}
+
+async function importCsv(filecontent: string) {
+  try {
+    con.log('Importing CSV');
+    const convertedData = await convertCsvToImportFormat(filecontent);
+    con.log('Converted data:', convertedData);
+
+    await importData(convertedData);
+    utils.flashm('CSV imported successfully');
+    alert(`CSV imported successfully! ${Object.keys(convertedData).length} animes imported.`);
+  } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    alert(`Error importing CSV: ${errorMsg}`);
+    con.error('CSV import error:', e);
   }
 }
 </script>

--- a/src/_minimal/components/settings/settings-local-sync-export.vue
+++ b/src/_minimal/components/settings/settings-local-sync-export.vue
@@ -14,7 +14,12 @@
 </template>
 
 <script lang="ts" setup>
-import { exportData, importData, convertCsvToImportFormat } from '../../../_provider/Local/import';
+import {
+  exportData,
+  importData,
+  convertCsvToImportFormat,
+  parseCSV,
+} from '../../../_provider/Local/import';
 import { status, type contentType } from '../../../_provider/definitions';
 import { getListbyType } from '../../../_provider/listFactory';
 import { getSyncMode, getProviderOption } from '../../../_provider/helper';
@@ -81,10 +86,17 @@ async function exportRemoteSync() {
 }
 
 async function exportFallbackSync() {
-  const exportObj = {
-    ...(await exportData()),
-    ...(await exportRemoteSync()),
-  };
+  let exportObj: Record<string, unknown>;
+  try {
+    exportObj = {
+      ...(await exportData()),
+      ...(await exportRemoteSync()),
+    };
+  } catch (e) {
+    con.error('Export failed', e);
+    alert(`Error exporting data: ${e instanceof Error ? e.message : String(e)}`);
+    return;
+  }
   con.log('Export', exportObj);
 
   const encodedUri = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
@@ -161,7 +173,9 @@ async function importFallbackSync(filecontent: string) {
   // Same header-column check convertCsvToImportFormat itself requires, so detection here can't
   // diverge from what actually makes a CSV valid - only the header line is checked, not the whole
   // file, so a JSON export whose data happens to contain the word "title" isn't misread as a CSV.
-  const headerCells = (trimmed.split('\n')[0] || '').split(',').map(h => h.trim().toLowerCase());
+  // Uses the same quote-aware parser convertCsvToImportFormat parses the body with, so a header
+  // that quotes its "Title" column (common from spreadsheet exports) is still recognized.
+  const headerCells = (parseCSV(trimmed)[0] || []).map(h => h.trim().toLowerCase());
   const isCsv = headerCells.includes('title');
 
   if (isJson) {

--- a/src/_minimal/components/settings/settings-local-sync-export.vue
+++ b/src/_minimal/components/settings/settings-local-sync-export.vue
@@ -14,7 +14,10 @@
 </template>
 
 <script lang="ts" setup>
-import { exportData, importData } from '../../../_provider/Local/import';
+import { exportData, importData, convertCsvToImportFormat } from '../../../_provider/Local/import';
+import { status, type contentType } from '../../../_provider/definitions';
+import { getListbyType } from '../../../_provider/listFactory';
+import { getSyncMode, getProviderOption } from '../../../_provider/helper';
 import FormButton from '../form/form-button.vue';
 import SettingsGeneral from './settings-general.vue';
 import SettingsLocalSyncFileUpload from './settings-local-sync-file-upload.vue';
@@ -26,17 +29,71 @@ defineProps({
   },
 });
 
+function getActiveListTypes(): contentType[] {
+  const primaryMode = api.settings.get('syncMode');
+  const secondaryMode = api.settings.get('syncModeSimkl');
+  const types = new Set<contentType>();
+
+  const primaryProvider = getProviderOption(primaryMode);
+  if (primaryProvider.anime) types.add('anime');
+  if (primaryProvider.manga) types.add('manga');
+
+  const secondaryProvider = getProviderOption(secondaryMode);
+  if (!primaryProvider.anime && secondaryProvider.anime) types.add('anime');
+  if ((!primaryProvider.manga || api.settings.get('splitTracking')) && secondaryProvider.manga) {
+    types.add('manga');
+  }
+
+  return Array.from(types);
+}
+
+async function exportRemoteSync() {
+  const exportObj = {};
+  const listTypes = getActiveListTypes();
+
+  for (let i = 0; i < listTypes.length; i++) {
+    const listType = listTypes[i];
+    const listProvider = getListbyType(getSyncMode(listType), [status.All, listType]);
+    // eslint-disable-next-line no-await-in-loop
+    const list = await listProvider.getCompleteList();
+
+    for (let j = 0; j < list.length; j++) {
+      const entry = list[j];
+      if (!entry.url) continue;
+      if (String(entry.uid).startsWith('local://')) continue;
+
+      exportObj[entry.url] = {
+        name: entry.title.replace(/^\[L\]\s*/, ''),
+        progress: entry.watchedEp ?? 0,
+        volumeprogress: entry.readVol ?? 0,
+        score: entry.score ?? 0,
+        status: entry.status ?? 0,
+        tags: entry.tags ?? '',
+        image: entry.image ?? '',
+        sUrl: entry.fn?.continueUrl?.() || entry.url,
+        source: listProvider.name,
+        type: listType,
+      };
+    }
+  }
+
+  return exportObj;
+}
+
 async function exportFallbackSync() {
-  const exportObj = await exportData();
+  const exportObj = {
+    ...(await exportData()),
+    ...(await exportRemoteSync()),
+  };
   con.log('Export', exportObj);
 
-  const encodedUri = `data:text/csv;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
+  const encodedUri = `data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
   try {
     const link = document.createElement('a');
     link.setAttribute('href', encodedUri);
     link.setAttribute(
       'download',
-      `malsync_${new Date().toJSON().slice(0, 10).replace(/-/g, '/')}.txt`,
+      `malsync_${new Date().toJSON().slice(0, 10).replace(/-/g, '/')}.json`,
     );
     document.body.appendChild(link);
 
@@ -47,8 +104,7 @@ async function exportFallbackSync() {
   utils.flashm('File exported');
 }
 
-function importFallbackSync(filecontent) {
-  con.log('Import FallbackSync', filecontent);
+function importJson(filecontent: string) {
   try {
     const iData = JSON.parse(filecontent);
     con.log('data', iData);
@@ -67,7 +123,7 @@ function importFallbackSync(filecontent) {
     importData(iData)
       .then(() => {
         utils.flashm('File imported');
-        alert('File imported');
+        alert('File imported successfully');
       })
       .catch(e => {
         if (e.message) {
@@ -76,8 +132,42 @@ function importFallbackSync(filecontent) {
         throw e;
       });
   } catch (e) {
-    alert('File has wrong formating');
-    con.error('File has wrong formating:', e);
+    alert('JSON file has wrong format');
+    con.error('JSON file has wrong format:', e);
+  }
+}
+
+async function importCsv(filecontent: string) {
+  try {
+    con.log('Importing CSV');
+    const convertedData = await convertCsvToImportFormat(filecontent);
+    con.log('Converted data:', convertedData);
+
+    await importData(convertedData);
+    utils.flashm('CSV imported successfully');
+    alert(`CSV imported successfully! ${Object.keys(convertedData).length} animes imported.`);
+  } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    alert(`Error importing CSV: ${errorMsg}`);
+    con.error('CSV import error:', e);
+  }
+}
+
+async function importFallbackSync(filecontent: string) {
+  con.log('Import FallbackSync', filecontent);
+
+  const trimmed = filecontent.trim();
+  const isJson = trimmed.startsWith('{');
+  const isCsv = trimmed.includes('Title') || trimmed.includes('title') || trimmed.includes('TITLE');
+
+  con.log('Detection - isJson:', isJson, 'isCsv:', isCsv);
+
+  if (isJson) {
+    importJson(filecontent);
+  } else if (isCsv) {
+    await importCsv(filecontent);
+  } else {
+    alert('File format not recognized. Please use JSON export or CSV with Title column.');
   }
 }
 </script>

--- a/src/_minimal/components/settings/settings-local-sync-export.vue
+++ b/src/_minimal/components/settings/settings-local-sync-export.vue
@@ -158,9 +158,11 @@ async function importFallbackSync(filecontent: string) {
 
   const trimmed = filecontent.trim();
   const isJson = trimmed.startsWith('{');
-  const isCsv = trimmed.includes('Title') || trimmed.includes('title') || trimmed.includes('TITLE');
-
-  con.log('Detection - isJson:', isJson, 'isCsv:', isCsv);
+  // Same header-column check convertCsvToImportFormat itself requires, so detection here can't
+  // diverge from what actually makes a CSV valid - only the header line is checked, not the whole
+  // file, so a JSON export whose data happens to contain the word "title" isn't misread as a CSV.
+  const headerCells = (trimmed.split('\n')[0] || '').split(',').map(h => h.trim().toLowerCase());
+  const isCsv = headerCells.includes('title');
 
   if (isJson) {
     importJson(filecontent);

--- a/src/_provider/Local/import.ts
+++ b/src/_provider/Local/import.ts
@@ -1,4 +1,5 @@
 import * as helper from './helper';
+import { search } from '../searchFactory';
 
 export async function exportData() {
   const data = await helper.getSyncList();
@@ -57,4 +58,102 @@ export async function importData(newData: {}) {
   }
 
   return 1;
+}
+
+export async function convertCsvToImportFormat(csvContent: string) {
+  const lines = csvContent.split('\n').filter(line => line.trim());
+  
+  if (lines.length === 0) {
+    throw new Error('CSV is empty');
+  }
+
+  const headers = lines[0].split(',').map(h => h.trim());
+  const titleIndex = headers.findIndex(h => h.toLowerCase() === 'title');
+  
+  if (titleIndex === -1) {
+    throw new Error('CSV must have a "Title" column');
+  }
+
+  const importedData = {};
+  const errors: string[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+
+    const parts = parseCSVLine(line);
+    const title = parts[titleIndex]?.trim();
+
+    if (!title) continue;
+
+    try {
+      con.log(`Searching for anime: ${title}`);
+      const results = await search(title, 'anime');
+
+      if (!results || results.length === 0) {
+        errors.push(`${title} - Not found`);
+        continue;
+      }
+
+      const result = results[0];
+      const malUrl = await result.malUrl();
+
+      if (!malUrl) {
+        errors.push(`${title} - No MAL URL found`);
+        continue;
+      }
+
+      const localKey = `local://${malUrl.split('/')[4]}/${malUrl.split('/')[3]}`;
+      
+      importedData[localKey] = {
+        name: result.name || title,
+        progress: result.list?.episode || 0,
+        volumeprogress: 0,
+        score: result.list?.score || 0,
+        status: 2, // Completed
+        tags: '',
+        image: result.image || '',
+        sUrl: malUrl,
+      };
+
+      con.log(`Successfully matched: ${title} -> ${result.name}`);
+    } catch (e) {
+      con.error(`Error searching for ${title}:`, e);
+      errors.push(`${title} - Error: ${String(e)}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    const errorMsg = `Import completed with ${errors.length} error(s):\n${errors.join('\n')}`;
+    utils.flashm(errorMsg, { error: true });
+    con.log(errorMsg);
+  }
+
+  if (Object.keys(importedData).length === 0) {
+    throw new Error('No animes found to import');
+  }
+
+  return importedData;
+}
+
+function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
 }

--- a/src/_provider/Local/import.ts
+++ b/src/_provider/Local/import.ts
@@ -1,5 +1,6 @@
 import * as helper from './helper';
 import { search } from '../searchFactory';
+import { status } from '../definitions';
 
 export async function exportData() {
   const data = await helper.getSyncList();
@@ -103,14 +104,20 @@ export async function convertCsvToImportFormat(csvContent: string) {
         continue;
       }
 
-      const localKey = `local://${malUrl.split('/')[4]}/${malUrl.split('/')[3]}`;
+      // Local keys are read back as local://{source}/{type}/{id} (see Local/single.ts and
+      // Local/list.ts, which pulls id/source out of the URL by fixed segment index) - "mal" here
+      // just marks that this entry was matched by title search rather than a real streaming site.
+      const malId = malUrl.split('/')[4];
+      const localKey = `local://mal/anime/${malId}`;
 
+      // A CSV only ever gives us a title, so there's no source for progress/score beyond what
+      // marking the entry Completed implies: the full episode count, and no personal score.
       importedData[localKey] = {
         name: result.name || title,
-        progress: result.list?.episode || 0,
+        progress: result.totalEp || 0,
         volumeprogress: 0,
-        score: result.list?.score || 0,
-        status: 2, // Completed
+        score: 0,
+        status: status.Completed,
         tags: '',
         image: result.image || '',
         sUrl: malUrl,

--- a/src/_provider/Local/import.ts
+++ b/src/_provider/Local/import.ts
@@ -40,6 +40,16 @@ export async function importData(newData: {}) {
 
   // import Data
   for (const k in newData) {
+    // exportRemoteSync() (settings-local-sync-export.vue) also folds already-synced entries -
+    // keyed by their real provider URL, not local://... - into the same export file as a record
+    // of what was tracked elsewhere. Those aren't Local Sync data and were never meant to be
+    // written back: Local's own list/single classes only ever look up local://-prefixed keys, so
+    // writing a raw provider URL as a storage key here would just leave it permanently orphaned.
+    if (!helper.getRegex('(anime|manga)').test(k)) {
+      con.log('Skip (not a local:// key)', k);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
     con.log('Set', k, newData[k]);
     await api.storage.set(k, newData[k]).catch(e => {
       if (e.message) {
@@ -62,13 +72,13 @@ export async function importData(newData: {}) {
 }
 
 export async function convertCsvToImportFormat(csvContent: string) {
-  const lines = csvContent.split('\n').filter(line => line.trim());
+  const rows = parseCSV(csvContent).filter(row => row.some(cell => cell.trim()));
 
-  if (lines.length === 0) {
+  if (rows.length === 0) {
     throw new Error('CSV is empty');
   }
 
-  const headers = lines[0].split(',').map(h => h.trim());
+  const headers = rows[0].map(h => h.trim());
   const titleIndex = headers.findIndex(h => h.toLowerCase() === 'title');
 
   if (titleIndex === -1) {
@@ -78,11 +88,10 @@ export async function convertCsvToImportFormat(csvContent: string) {
   const importedData = {};
   const errors: string[] = [];
 
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.trim()) continue;
+  for (let i = 1; i < rows.length; i++) {
+    const parts = rows[i];
+    if (!parts.some(cell => cell.trim())) continue;
 
-    const parts = parseCSVLine(line);
     const title = parts[titleIndex]?.trim();
 
     if (!title) continue;
@@ -131,9 +140,12 @@ export async function convertCsvToImportFormat(csvContent: string) {
   }
 
   if (errors.length > 0) {
-    const errorMsg = `Import completed with ${errors.length} error(s):\n${errors.join('\n')}`;
+    // flashm renders this as HTML (via DOMPurify) - '\n' has no visual effect there, so plain
+    // '\n'-joined text collapses every error onto one unreadable line. '<br>' is what actually
+    // produces separate lines; the log line below keeps the '\n'-joined form for the console.
+    const errorMsg = `Import completed with ${errors.length} error(s):<br>${errors.join('<br>')}`;
     utils.flashm(errorMsg, { error: true });
-    con.log(errorMsg);
+    con.log(`Import completed with ${errors.length} error(s):\n${errors.join('\n')}`);
   }
 
   if (Object.keys(importedData).length === 0) {
@@ -143,24 +155,57 @@ export async function convertCsvToImportFormat(csvContent: string) {
   return importedData;
 }
 
-function parseCSVLine(line: string): string[] {
-  const result: string[] = [];
+// Parses the whole file rather than splitting it into lines first: a quoted field can legally
+// contain a literal newline (common in real-world exports with multi-line notes), so a naive
+// split('\n') before parsing would tear that field's row in two before quote-awareness ever gets
+// a chance to see it. Also handles RFC4180's escaped-quote rule (a "" pair inside a quoted field
+// is a literal ") - a plain "any quote toggles the mode" parser desyncs on a title like `The
+// "Best" Anime` and corrupts every field after it on the line.
+export function parseCSV(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
   let current = '';
   let inQuotes = false;
 
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (content[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+      continue;
+    }
 
     if (char === '"') {
-      inQuotes = !inQuotes;
-    } else if (char === ',' && !inQuotes) {
-      result.push(current);
+      inQuotes = true;
+    } else if (char === ',') {
+      row.push(current);
+      current = '';
+    } else if (char === '\r') {
+      // Swallowed on its own; the following '\n' (or the '\n'-only case below) ends the row.
+    } else if (char === '\n') {
+      row.push(current);
+      rows.push(row);
+      row = [];
       current = '';
     } else {
       current += char;
     }
   }
 
-  result.push(current);
-  return result;
+  // Last row has no trailing newline to close it.
+  if (current !== '' || row.length > 0) {
+    row.push(current);
+    rows.push(row);
+  }
+
+  return rows;
 }

--- a/src/_provider/Local/import.ts
+++ b/src/_provider/Local/import.ts
@@ -1,4 +1,5 @@
 import * as helper from './helper';
+import { search } from '../searchFactory';
 
 export async function exportData() {
   const data = await helper.getSyncList();
@@ -57,4 +58,102 @@ export async function importData(newData: {}) {
   }
 
   return 1;
+}
+
+export async function convertCsvToImportFormat(csvContent: string) {
+  const lines = csvContent.split('\n').filter(line => line.trim());
+
+  if (lines.length === 0) {
+    throw new Error('CSV is empty');
+  }
+
+  const headers = lines[0].split(',').map(h => h.trim());
+  const titleIndex = headers.findIndex(h => h.toLowerCase() === 'title');
+
+  if (titleIndex === -1) {
+    throw new Error('CSV must have a "Title" column');
+  }
+
+  const importedData = {};
+  const errors: string[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+
+    const parts = parseCSVLine(line);
+    const title = parts[titleIndex]?.trim();
+
+    if (!title) continue;
+
+    try {
+      con.log(`Searching for anime: ${title}`);
+      const results = await search(title, 'anime');
+
+      if (!results || results.length === 0) {
+        errors.push(`${title} - Not found`);
+        continue;
+      }
+
+      const result = results[0];
+      const malUrl = await result.malUrl();
+
+      if (!malUrl) {
+        errors.push(`${title} - No MAL URL found`);
+        continue;
+      }
+
+      const localKey = `local://${malUrl.split('/')[4]}/${malUrl.split('/')[3]}`;
+
+      importedData[localKey] = {
+        name: result.name || title,
+        progress: result.list?.episode || 0,
+        volumeprogress: 0,
+        score: result.list?.score || 0,
+        status: 2, // Completed
+        tags: '',
+        image: result.image || '',
+        sUrl: malUrl,
+      };
+
+      con.log(`Successfully matched: ${title} -> ${result.name}`);
+    } catch (e) {
+      con.error(`Error searching for ${title}:`, e);
+      errors.push(`${title} - Error: ${String(e)}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    const errorMsg = `Import completed with ${errors.length} error(s):\n${errors.join('\n')}`;
+    utils.flashm(errorMsg, { error: true });
+    con.log(errorMsg);
+  }
+
+  if (Object.keys(importedData).length === 0) {
+    throw new Error('No animes found to import');
+  }
+
+  return importedData;
+}
+
+function parseCSVLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current);
+  return result;
 }

--- a/src/_provider/listFactory.ts
+++ b/src/_provider/listFactory.ts
@@ -27,7 +27,7 @@ export function getOnlyList(...args) {
   return getListObj(args);
 }
 
-export function getListbyType(syncMode: string, args = []) {
+export function getListbyType(syncMode: string, args: any[] = []) {
   return getListObj(args, syncMode);
 }
 


### PR DESCRIPTION
- Implement CSV import for anime lists (Netflix, Prime Video, etc.)
- Auto-detect anime titles using the extension's search function
- Parse CSV with support for quoted fields and flexible formatting
- Export now includes both Local Sync fallback data and synchronized data from active providers (MyAnimeList, AniList, etc.)
- JSON export format includes comprehensive anime/manga metadata
- Graceful error handling with user-friendly messages
- Support for both import and export operations in settings