### PR TITLE
fix: make the repo installable under npm 12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,6 @@
 engine-strict=true
 min-release-age=2
+; npm 12 refuses git dependencies by default (allow-git=none). `to-string-loader`
+; is declared as a git dep in this repo's own package.json, so `root` is the
+; narrowest opt-in: it permits our own git deps and still refuses transitive ones.
+allow-git=root

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "@vue/eslint-config-typescript": "13.0.0",
         "archiver": "^8.0.0",
         "chai": "^6.2.2",
+        "cheerio": "^1.2.0",
         "chrome-webstore-upload": "^4.0.4",
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "node": ">=24.0.0"
   },
   "devDependencies": {
-    "@ghostery/adblocker-puppeteer": "^2.18.1",
     "@cspell/eslint-plugin": "10.0.1",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "9.39.4",
+    "@ghostery/adblocker-puppeteer": "^2.18.1",
     "@stylistic/eslint-plugin": "3.1.0",
     "@types/chai": "^5.2.3",
     "@types/eslint": "9.6.1",
@@ -28,6 +28,7 @@
     "@vue/eslint-config-typescript": "13.0.0",
     "archiver": "^8.0.0",
     "chai": "^6.2.2",
+    "cheerio": "^1.2.0",
     "chrome-webstore-upload": "^4.0.4",
     "cross-env": "^7.0.3",
     "css-loader": "^7.1.4",
@@ -140,5 +141,8 @@
     "vue-tsc": "^3.3.5",
     "vuedraggable": "^4.1.0",
     "webext-patterns": "^1.5.1"
+  },
+  "allowScripts": {
+    "puppeteer@25.3.0": true
   }
 }


### PR DESCRIPTION
`npm ci` currently fails outright on npm 12, so the repo cannot be set up at all on that version:

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "to-string-loader@git+ssh://git@github.com/gajus/to-string-loader.git#356751f67ccbfc52af01e1712eb4ba8cb325f3a5"
```

npm 12 changed the default to `allow-git=none`. `to-string-loader` is declared as a git dependency, so nothing installs.

`allow-git=root` is the narrowest opt-in that fixes it: it permits the git dependencies declared in this repo's own `package.json` and still refuses transitive ones. I checked the lockfile before picking it — `to-string-loader` is the only git dependency, and there are no tarball-URL dependencies, so the companion default `allow-remote=none` is not a problem here.

The second commit is a separate small thing in the same area: `webpackConfig/autoUrls.mjs` imports `cheerio` but never declared it. It has only ever resolved transitively, which means a dependency bump could have removed it and broken the nightly autoUrls job with no warning.

Verified on Windows with npm 12.0.1 / Node 24.18:

- `npm ci` completes
- `npm run lint:ci` clean
- `npm run test:ts:ci` — 662 passing, 2 pending

Two install scripts stay blocked by npm 12's other new default (`puppeteer` and `unrs-resolver`). Lint and the TS tests pass regardless; only `npm run test:headless` needs `npm install-scripts approve puppeteer` locally. CI is unaffected since it already sets `PUPPETEER_SKIP_DOWNLOAD`.
