### PR TITLE
fix: restore the Rumble player match lost to a duplicate key

### DIFF
--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -846,7 +846,7 @@ module.exports = {
     match: ['*://rumble.com/embed/*'],
   },
   // aninexus
-  rumble: {
+  aninexusPlayer: {
     match: ['*://fle-rvd0i9o8-moo.com/*', '*://dhtpre.com/*'],
   },
   // miruro


### PR DESCRIPTION
`playerUrls.js` declares `rumble` twice — once for AnimeXin and once for Aninexus:

```js
  // animexin
  rumble: {
    match: ['*://rumble.com/embed/*'],
  },
  // aninexus
  rumble: {
    match: ['*://fle-rvd0i9o8-moo.com/*', '*://dhtpre.com/*'],
  },
```

It is an object literal, so the second declaration silently overwrites the first. `*://rumble.com/embed/*` never reaches the manifest, and episodes played through Rumble on AnimeXin are not tracked.

The file declares 156 entries but only exported 155:

```
node -e "console.log(Object.keys(require('./src/pages/playerUrls.js')).length)"
155   before
156   after
```

Both consuming pages are still shipped, so both sets of URLs are needed. Renaming the Aninexus entry to `aninexusPlayer` keeps them both. The keys are only used by `generateMatchExcludes`, which iterates them and concatenates `.match`, so the name itself carries no meaning and renaming is safe.
