### PR TITLE
fix(AnimeSama): add missing player hosts and fix the search quicklink

### DIFF
--- a/src/pages/AnimeSama/main.ts
+++ b/src/pages/AnimeSama/main.ts
@@ -2,7 +2,7 @@ import { pageInterface } from '../pageInterface';
 
 export const AnimeSama: pageInterface = {
   name: 'AnimeSama',
-  domain: 'https://anime-sama.tv',
+  domain: 'https://anime-sama.to',
   languages: ['French'],
   type: 'anime',
   isSyncPage(url) {

--- a/src/pages/AnimeSama/meta.json
+++ b/src/pages/AnimeSama/meta.json
@@ -1,5 +1,5 @@
 {
-  "search": "https://anime-sama.tv/catalogue/?search={searchterm}",
+  "search": "https://anime-sama.to/catalogue/?search={searchtermPlus}",
   "urls": {
     "match": [
       "*://anime-sama.tv/*",

--- a/src/pages/AnimeSama/tests.json
+++ b/src/pages/AnimeSama/tests.json
@@ -1,14 +1,14 @@
 {
   "title": "AnimeSama",
-  "url": "https://anime-sama.eu",
+  "url": "https://anime-sama.to",
   "testCases": [
     {
-      "url": "https://anime-sama.eu/catalogue/love-live-sunshine/saison1/vostfr/",
+      "url": "https://anime-sama.to/catalogue/love-live-sunshine/saison1/vostfr/",
       "expected": {
         "sync": true,
         "title": "Love Live! Sunshine!!",
         "identifier": "love-live-sunshine/saison1",
-        "overviewUrl": "https://anime-sama.eu/catalogue/love-live-sunshine",
+        "overviewUrl": "https://anime-sama.to/catalogue/love-live-sunshine",
         "episode": 1,
         "uiSelector": false
       }

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -597,9 +597,9 @@ module.exports = {
   videobin: {
     match: ['*://videobin.co/*'],
   },
-  // animewho
+  // animewho animesama
   uqload: {
-    match: ['*://uqload.com/*'],
+    match: ['*://uqload.com/*', '*://uqload.is/*'],
   },
   // animewho
   evoload: {
@@ -836,6 +836,18 @@ module.exports = {
   // animesama
   oneupload: {
     match: ['*://oneupload.to/*'],
+  },
+  // animesama
+  ansembed: {
+    match: ['*://*.ansembed.net/*'],
+  },
+  // animesama
+  embed4me: {
+    match: ['*://*.embed4me.com/*'],
+  },
+  // animesama
+  minochinos: {
+    match: ['*://*.minochinos.com/*'],
   },
   // animexin
   vimeo: {


### PR DESCRIPTION
Two unrelated breakages on the same page, one commit each.

## Players

Anime-Sama offers five players per episode. Four of them were not tracked, because `content/iframe.js` was never injected into their hosts.

Read off the `eps1`..`eps5` globals on an episode page:

| # | host | state |
|---|---|---|
| 1 | `ansembed.net` | missing |
| 2 | `lpayer.embed4me.com` | missing |
| 3 | `video.sibnet.ru` | already covered |
| 4 | `uqload.is` | entry existed, but only as `uqload.com` |
| 5 | `minochinos.com` | missing |

`uqload` is the interesting one: not a new player, just a host that moved TLD with nobody following it.

Verified with the extension loaded, on `Tensei Shitara Slime Datta Ken` S4 E16:

```
iframe.js  Iframe ansembed.net
iframe.js  Iframe lpayer.embed4me.com
iframe.js  M Player https://lpayer.embed4me.com/#5vzjj {current: 108.809008, duration: 1440.009, paused: false}
```

Both new hosts inject, and the player reports a real position. Sync, progress bar and resume all behave normally afterwards.

Used `*://*.embed4me.com/*` rather than pinning the current `lpayer.` subdomain, since these hosts rotate subdomains. Only `.is` was added for `uqload` — the one TLD actually observed, no guessing on the others.

## Search quicklink

The search quicklink was unusable. `anime-sama.tv` redirects to `anime-sama.to` but drops the path and the query on the way, so

```
https://anime-sama.tv/catalogue/?search=no+game+no+life
```

lands on the bare homepage with no search performed.

Switched the search URL and the `domain` field to `anime-sama.to`, which is where `.tv` redirects and what the site serves today.

Also switched to `{searchtermPlus}` so the URL matches what the site's own search emits. Worth being explicit that this part was **not** the cause: `.to` accepts `%20` and `+` alike and returns the same result. The broken link was purely the domain.

```
before  https://anime-sama.tv/catalogue/?search=no%20game%20no%20life
after   https://anime-sama.to/catalogue/?search=no+game+no+life
```

## Checked

- `npm run lint:ci` clean
- `npm run test:ts:ci` — 662 passing, including the `quicklinksBuilder / Title Search` suite
- all five embed URLs matched against the patterns with `webext-patterns`
- the four new hosts present in the generated manifest's `content/iframe.js` entry

## Noted but not touched

`anime-sama.eu` is NXDOMAIN and `anime-sama.fr` returns SERVFAIL in this page's match patterns. Left alone: out of scope here, and SERVFAIL is not proof a domain is gone. Happy to drop `.eu` separately if you want it.
