### PR TITLE
fix(test): unbreak the headless page tests (missing chrome.storage.onChanged stub)

### DIFF
--- a/test/headless/test.js
+++ b/test/headless/test.js
@@ -409,28 +409,33 @@ async function singleCase(block, test, page, testPage, retry = 0) {
             get: function(keys, callback) {
               console.log('chrome.storage.local.get', keys, callback);
               callback({});
-              return promise.resolve({});
+              return Promise.resolve({});
             },
             set: function(items, callback) {
               console.log('chrome.storage.local.set', items, callback);
               if (callback) {
                 callback();
               }
-              return promise.resolve({});
+              return Promise.resolve({});
             }
           },
           sync: {
             get: function(keys, callback) {
               console.log('chrome.storage.sync.get', keys, callback);
               callback({});
-              return promise.resolve({});
+              return Promise.resolve({});
             },
             set: function(items, callback) {
               console.log('chrome.storage.sync.set', items, callback);
               if (callback) {
                 callback();
               }
-              return promise.resolve({});
+              return Promise.resolve({});
+            }
+          },
+          onChanged: {
+            addListener: function(callback) {
+              console.log('chrome.storage.onChanged.addListener', callback);
             }
           }
         },


### PR DESCRIPTION
Every page test currently fails with:

```
ReferenceError: MalSyncTest is not defined
```

That message is misleading. The bundle is injected fine — it **throws while being evaluated**, so it never reaches the line that assigns `window.MalSyncTest`.

## Cause

`src/utils/emitter.ts` calls `storageOnChanged` at module level, outside any function:

```ts
if (typeof api !== 'undefined' && api && api.type === 'webextension') {
  api.storage.storageOnChanged((changes, namespace) => { ... });
}
```

which reaches:

```ts
storageOnChanged(cb) {
  chrome.storage.onChanged.addListener(cb);
}
```

The harness stub defined `chrome.storage.local` and `chrome.storage.sync`, but not `chrome.storage.onChanged`. So `.addListener` is read off `undefined` and the whole bundle dies at import time.

`emitter.ts` is imported by `syncPage.ts`, so this is not specific to any page — it affects the entire page test suite.

## How I confirmed it

Injected jQuery, the harness's own chrome stub and `test/dist/testCode.js` into a live page with puppeteer, listening on `pageerror`. Adding the `onChanged` entry flips `typeof window.MalSyncTest` from `undefined` to `function`, and no error is raised during evaluation.

End to end on a real page test, with `FILES` scoped to one fixture:

```
AnimeSama
  https://anime-sama.to/catalogue/love-live-sunshine/saison1/vostfr/
    Cached
    Passed
```

exit code 0. Before this change the same run reported `MalSyncTest is not defined`.

## Also in here

`promise.resolve` → `Promise.resolve` in the four storage stubs. That was **not** the blocker — those functions aren't reached during evaluation — but lowercase `promise` is undefined, so any code that called `chrome.storage.local.get` would have thrown.

## Note

This only unblocks the harness. Several page fixtures point at domains that no longer resolve and will need their own updates — `anigo.to` for instance is NXDOMAIN, so `src/pages-chibi/implementations/AniGo/tests.json` fails on navigation regardless of this fix. Those are separate and I did not touch them here.
