### PR TITLE
feat: remember the playback position regardless of the sync mode

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -237,6 +237,10 @@
             }
         }
     },
+    "syncPage_flashm_resumePlay": {
+        "message": "Start the video, then click resume again",
+        "description": "Shown when resuming did not take effect because playback has not started yet"
+    },
     "syncPage_flashm_sync_anime": {
         "message": "Update $page$ to episode $epNr$",
         "description": "Update MAL to episode 3",
@@ -1274,6 +1278,10 @@
     "settings_Video_Fullscreen": {
         "message": "Auto fullscreen",
         "description": "Auto fullscreen toggle"
+    },
+    "settings_Video_RememberPosition": {
+        "message": "Remember playback position",
+        "description": "Toggle for storing where playback stopped so it can be resumed later"
     },
     "settings_Video_Resume": {
         "message": "Auto resume",

--- a/src/_minimal/components/settings/settings-structure-video.ts
+++ b/src/_minimal/components/settings/settings-structure-video.ts
@@ -15,8 +15,18 @@ export const video: ConfObj[] = [
     component: SettingsGeneral,
   },
   {
+    key: 'rememberPosition',
+    title: () => api.storage.lang('settings_Video_RememberPosition'),
+    props: {
+      component: 'checkbox',
+      option: 'rememberPosition',
+    },
+    component: SettingsGeneral,
+  },
+  {
     key: 'autoresume',
     title: () => api.storage.lang('settings_Video_Resume'),
+    condition: () => api.settings.get('rememberPosition'),
     props: {
       component: 'checkbox',
       option: 'autoresume',

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -69,6 +69,7 @@ export const settingsObj = {
     quicklinksPosition: 'default',
 
     autofull: false,
+    rememberPosition: true,
     autoresume: false,
     autoNextEp: false,
     highlightAllEp: false,

--- a/src/pages-sync/playbackPosition.ts
+++ b/src/pages-sync/playbackPosition.ts
@@ -1,0 +1,240 @@
+import { PlayerSingleton } from '../utils/player';
+import { localStore } from '../utils/localStore';
+import { resumeMessageElement } from './messageElements';
+import type { ProgressElement } from './trackingMode/TrackingModeInterface';
+
+const logger = con.m('Resume', '#348fff');
+
+/** Below this many seconds there is nothing worth resuming to. */
+const MIN_RESUME_SECONDS = 45;
+
+const SAVE_INTERVAL = 10 * 1000;
+
+/** How close the player has to land for a seek to count as having happened. */
+const RESUME_TOLERANCE = 3;
+
+/** Grace period before telling the user the seek did not take, in ms. */
+const RESUME_HINT_DELAY = 2500;
+
+/**
+ * Remembers where playback stopped so the position can be offered again on the next visit.
+ *
+ * Deliberately not part of the tracking modes: which mode is selected decides *when the
+ * list gets updated*, which has nothing to do with whether the position is worth
+ * remembering. Keeping it separate means `instant` and `manual` get it too, and that it
+ * survives the cases where there is nothing to sync at all — a rewatch, or an episode
+ * already marked as watched.
+ *
+ * Source agnostic on purpose. The caller feeds it through `report()`, so video progress
+ * comes from the player while manga progress keeps coming from its own tracking mode.
+ */
+export class PlaybackPosition {
+  private saved: ProgressElement | null = null;
+
+  /** Set once the prompt has been acted on, so it is offered only once per visit. */
+  private resumed = false;
+
+  /** Held while playback is behind the stored position, to avoid overwriting it. */
+  private saveBlocked = false;
+
+  private saveDebounce = true;
+
+  private finished = false;
+
+  private stopped = false;
+
+  /** Seek target while a resume has been asked for but not observed yet. */
+  private pendingResume: number | null = null;
+
+  private hintTimeout: NodeJS.Timeout | null = null;
+
+  /**
+   * @param key storage key, unique per entry and episode
+   * @param allowResume whether a resume prompt may be shown. Off for readers, where
+   *   there is no player to seek.
+   */
+  constructor(
+    private readonly key: string,
+    private readonly allowResume = true,
+  ) {}
+
+  /** Reads what a previous visit stored. Call before the first `report()`. */
+  start() {
+    this.saved = this.read();
+    this.resumed = !this.saved;
+    this.saveBlocked = Boolean(this.saved);
+    if (this.saved) logger.debug('Stored position', this.saved);
+  }
+
+  /** The stored position, for the ghost bar on the tracking UI. */
+  getSaved() {
+    return this.saved;
+  }
+
+  report(progress: ProgressElement) {
+    if (this.stopped || this.finished) return;
+
+    this.confirmResume(progress);
+
+    // Caught up with the stored position: stop holding back saves, drop the prompt.
+    if (this.saveBlocked && this.saved && progress.progress >= this.saved.progress) {
+      this.saveBlocked = false;
+      if (!this.resumed && j.$('#MALSyncResume').length) {
+        this.resumed = true;
+        j.$('#MALSyncResume').parentsUntil('.flash').remove();
+      }
+    }
+
+    // The episode has been watched through, there is nothing left to come back to.
+    const trigger = Number(progress.progressTrigger);
+    if (trigger && progress.progress >= trigger) {
+      this.finished = true;
+      this.clear();
+      return;
+    }
+
+    if (this.offerResume()) return;
+
+    this.persist(progress);
+  }
+
+  /**
+   * Seeking is fire and forget — `setTime` posts a message to the player frame and gets
+   * nothing back, and it is simply dropped when that frame has no player yet, which is
+   * what happens when the video has not been started. So the prompt stays up until the
+   * player is actually seen at the requested position, leaving the offer clickable again
+   * once playback has begun.
+   */
+  private confirmResume(progress: ProgressElement) {
+    if (this.pendingResume === null) return;
+    if (progress.current < this.pendingResume - RESUME_TOLERANCE) return;
+
+    logger.log('Resumed at', progress.current);
+    this.pendingResume = null;
+    this.clearHint();
+    this.resumed = true;
+    this.saveBlocked = false;
+    j.$('#MALSyncResume').parentsUntil('.flash').remove();
+  }
+
+  /**
+   * Nothing comes back from a dropped seek, so tell the user what to do about it rather
+   * than leaving a prompt that looks unresponsive.
+   */
+  private scheduleHint() {
+    this.clearHint();
+    this.hintTimeout = setTimeout(() => {
+      if (this.pendingResume === null) return;
+      utils.flashm(api.storage.lang('syncPage_flashm_resumePlay'), { type: 'resumeHint' });
+    }, RESUME_HINT_DELAY);
+  }
+
+  private clearHint() {
+    if (this.hintTimeout) {
+      clearTimeout(this.hintTimeout);
+      this.hintTimeout = null;
+    }
+  }
+
+  /** @returns true when a prompt is on screen, so saving is left alone this tick. */
+  private offerResume(): boolean {
+    if (!this.allowResume || this.resumed) return false;
+
+    const { saved } = this;
+    if (!saved || !saved.current || saved.current < MIN_RESUME_SECONDS) {
+      // Too short to be worth resuming, and it will not grow — stop checking.
+      this.resumed = true;
+      this.saveBlocked = false;
+      return false;
+    }
+
+    // No way to seek yet. Keep the offer pending rather than dropping it, an iframe
+    // player only becomes seekable once it has reported in.
+    if (!PlayerSingleton.getInstance().canSetTime()) return false;
+
+    if (j.$('#MALSyncResume').length) return true;
+
+    if (api.settings.get('autoresume')) {
+      this.resumeTo(saved);
+      this.resumed = true;
+      return true;
+    }
+
+    const message = resumeMessageElement(
+      api.storage.lang('syncPage_flashm_resumeMsg', [PlaybackPosition.formatTime(saved.current)]),
+    );
+
+    const prompt = utils.flashm(message.innerHTML, {
+      permanent: true,
+      error: false,
+      type: 'resume',
+      minimized: false,
+      position: 'top',
+    });
+
+    prompt.find('.sync').on('click', () => {
+      this.pendingResume = saved.current!;
+      this.resumeTo(saved);
+      this.scheduleHint();
+    });
+
+    prompt.find('.resumeClose').on('click', () => {
+      this.pendingResume = null;
+      this.clearHint();
+      this.resumed = true;
+      this.saveBlocked = false;
+      prompt.remove();
+    });
+
+    return true;
+  }
+
+  private persist(progress: ProgressElement) {
+    if (this.saveBlocked || !this.saveDebounce) return;
+
+    logger.debug('Set Resume', progress);
+    localStore.setItem(this.key, JSON.stringify(progress));
+
+    this.saveDebounce = false;
+    setTimeout(() => {
+      this.saveDebounce = true;
+    }, SAVE_INTERVAL);
+  }
+
+  private resumeTo(state: ProgressElement) {
+    if (!state.current) return;
+    logger.log('Resume to', state.current);
+    PlayerSingleton.getInstance().setTime(state.current);
+  }
+
+  private read(): ProgressElement | null {
+    const stored = localStore.getItem(this.key);
+    if (!stored) return null;
+    try {
+      return JSON.parse(stored) as ProgressElement;
+    } catch (e) {
+      logger.error('Could not read the stored position', e);
+      localStore.removeItem(this.key);
+      return null;
+    }
+  }
+
+  clear() {
+    logger.debug('Clear', this.key);
+    localStore.removeItem(this.key);
+    this.saved = null;
+  }
+
+  stop() {
+    this.stopped = true;
+    this.pendingResume = null;
+    this.clearHint();
+    j.$('#MALSyncResume').parentsUntil('.flash').remove();
+  }
+
+  static formatTime(seconds: number) {
+    const minutes = Math.floor(seconds / 60);
+    const sec = Math.floor(seconds - minutes * 60);
+    return `${minutes}:${String(sec).padStart(2, '0')}`;
+  }
+}

--- a/src/pages-sync/syncPage.ts
+++ b/src/pages-sync/syncPage.ts
@@ -7,13 +7,12 @@ import { SearchClass } from '../_provider/Search/vueSearchClass';
 import { emitter } from '../utils/emitter';
 import { Cache } from '../utils/Cache';
 import { NotFoundError, UrlNotSupportedError } from '../_provider/Errors';
-import { localStore } from '../utils/localStore';
 import { getPageConfig } from '../utils/test';
 import { status } from '../_provider/definitions';
 import { getTrackingMode, TrackingModeType } from './trackingMode';
-import type { ProgressElement, TrackingModeInterface } from './trackingMode/TrackingModeInterface';
+import type { TrackingModeInterface } from './trackingMode/TrackingModeInterface';
+import { PlaybackPosition } from './playbackPosition';
 import {
-  resumeMessageElement,
   trackingBarElement,
   trackingErrorElement,
   trackingNoteElement,
@@ -101,6 +100,30 @@ export class SyncPage {
     this.page.domain = new URL(window.location.href).origin;
   }
 
+  protected playbackPosition: PlaybackPosition | null = null;
+
+  /**
+   * Starts remembering the playback position for this episode.
+   *
+   * Called from the sync page branch rather than from `startSyncHandling`, so it is not
+   * tied to the tracking mode nor to there being anything to sync. Both of those cut it
+   * short before: `instant` and `manual` have no progress listener at all, and an episode
+   * already marked as watched never reaches the sync handling.
+   */
+  private startPlaybackPosition(state: pageState) {
+    this.playbackPosition?.stop();
+    this.playbackPosition = null;
+
+    if (!api.settings.get('rememberPosition')) return null;
+
+    this.playbackPosition = new PlaybackPosition(
+      `progress/${state.identifier}/${state.episode}/v1`,
+    );
+    this.playbackPosition.start();
+
+    return this.playbackPosition;
+  }
+
   public openNextEp() {
     if (typeof this.page.sync.nextEpUrl !== 'undefined') {
       if (this.page.isSyncPage(this.url)) {
@@ -142,6 +165,8 @@ export class SyncPage {
       this.trackingModeInstance.stop();
       this.trackingModeInstance = undefined;
     }
+    this.playbackPosition?.stop();
+    this.playbackPosition = null;
     $('#flashinfo-div, #flash-div-bottom, #flash-div-top, #malp').remove();
     clearInterval(this.imageFallbackInterval);
   }
@@ -205,9 +230,18 @@ export class SyncPage {
         state.volume = this.page.sync.getVolume(this.url);
       }
       if (this.page.type === 'anime') {
+        const positionTracker = this.startPlaybackPosition(state);
         const playerInstance = PlayerSingleton.getInstance().startTracking();
         playerInstance.addListener('syncPage', item => {
           this.autoNextEp(item);
+          if (positionTracker && item.duration) {
+            positionTracker.report({
+              progress: item.current / item.duration,
+              progressTrigger: Number(api.settings.get('videoDuration')) / 100,
+              current: item.current,
+              total: item.duration,
+            });
+          }
         });
       }
       logger.m('Sync', 'green').log(state);
@@ -350,7 +384,7 @@ export class SyncPage {
     let tracking: InstanceType<ReturnType<typeof getTrackingMode>> | null = null;
     if (this.page.type === 'manga' && api.settings.get('readerTracking')) {
       try {
-        tracking = new (getTrackingMode('manga' as TrackingModeType))();
+        tracking = new (getTrackingMode('manga'))();
         await tracking.start(this);
       } catch (e) {
         logger.error(e);
@@ -405,15 +439,12 @@ export class SyncPage {
     const flashEl = utils.flashm(message, tracking.flashOptions());
 
     if ('addListener' in tracking) {
-      let saveDebounce = true;
-
-      const localItem = localStore.getItem(progressStorageKey);
-      const lastProgress: ProgressElement | null = localItem
-        ? (JSON.parse(localItem) as ProgressElement)
-        : null;
-      let resumed = !lastProgress;
-
-      let saveBlocked = Boolean(lastProgress);
+      // Anime uses the tracker started with the page, so the position outlives this flow.
+      // Reader progress comes from the manga tracking mode instead, so it gets its own.
+      const readerPosition =
+        this.page.type === 'anime' ? null : new PlaybackPosition(progressStorageKey, false);
+      readerPosition?.start();
+      const position = readerPosition ?? this.playbackPosition;
 
       tracking.addListener(progress => {
         let finalPercent = Number(progress.progress);
@@ -428,6 +459,7 @@ export class SyncPage {
           flashEl.find('.ms-progress').css('width', `${finalPercent * 100}%`);
           flashEl.find('#malSyncProgress').removeClass('ms-loading').removeClass('ms-done');
 
+          const lastProgress = position?.getSaved();
           if (lastProgress) {
             let lastProgressFinalPercent = Number(lastProgress.progress);
             if (progress.progressTrigger && Number(progress.progressTrigger)) {
@@ -445,67 +477,7 @@ export class SyncPage {
           }
         }
 
-        // Save progress
-        if (saveBlocked && lastProgress && progress.progress >= lastProgress.progress) {
-          saveBlocked = false;
-          if (!resumed && j.$('#MALSyncResume').length) {
-            resumed = true;
-            j.$('#MALSyncResume').parentsUntil('.flash').remove();
-          }
-        }
-
-        if (
-          'resumeTo' in tracking &&
-          'getResumeText' in tracking &&
-          'canResume' in tracking &&
-          !resumed &&
-          lastProgress &&
-          tracking.canResume(lastProgress)
-        ) {
-          if (j.$('#MALSyncResume').length) {
-            return;
-          }
-
-          if (api.settings.get('autoresume')) {
-            tracking.resumeTo(lastProgress);
-            resumed = true;
-            return;
-          }
-
-          const resumeTimeString = tracking.getResumeText(lastProgress) || '';
-          const resumeMessageDiv = resumeMessageElement(
-            api.storage.lang('syncPage_flashm_resumeMsg', [resumeTimeString]),
-          );
-
-          const resumeMsg = utils.flashm(resumeMessageDiv.innerHTML, {
-            permanent: true,
-            error: false,
-            type: 'resume',
-            minimized: false,
-            position: 'top',
-          });
-
-          resumeMsg.find('.sync').on('click', () => {
-            tracking.resumeTo(lastProgress);
-            resumed = true;
-            resumeMsg.remove();
-          });
-
-          resumeMsg.find('.resumeClose').on('click', function () {
-            resumed = true;
-            resumeMsg.remove();
-          });
-          return;
-        }
-
-        if (!saveBlocked && saveDebounce) {
-          logger.debug('Set Resume', progress);
-          localStore.setItem(progressStorageKey, JSON.stringify(progress));
-          saveDebounce = false;
-          setTimeout(() => {
-            saveDebounce = true;
-          }, 10000);
-        }
+        readerPosition?.report(progress);
       });
     }
 
@@ -533,7 +505,10 @@ export class SyncPage {
 
     flashEl.remove();
 
-    localStore.removeItem(progressStorageKey);
+    // The stored position is not dropped here on purpose. It is cleared once the episode
+    // has actually been watched through, which is not the same moment as the list being
+    // updated — `instant` syncs after `delay` seconds, and the sync button can be pressed
+    // at any point.
 
     // Debugging
     logger.log('overviewUrl', this.page.sync.getOverviewUrl(this.url));


### PR DESCRIPTION
Closes #4102.

Selecting `Instant` or `Manual` as the anime sync mode silently turns off the progress bar, the stored playback position and the resume prompt. They all sit behind one guard in `startSyncHandling`:

```js
if ('addListener' in tracking) { ... }
```

and only `VideoStrategy` and `MangaStrategy` implement it.

## Why extending the strategies would not have been enough

Two other things cut the position short even where the listener exists:

- it was dropped in `startSyncHandling` when tracking ended, which is when *the list gets updated* rather than when *the episode is over*. Those only coincide in `video` mode — `instant` syncs after `delay` seconds, 0 by default, so the position would be wiped almost immediately
- an episode already marked as watched never reaches `startSyncHandling`, because `checkSync` returns false, so a rewatch or a revisit got nothing either

So the lifetime had to change, not just the strategy.

## What this does

The position becomes its own concern, in `playbackPosition.ts`, fed from the sync page branch of `handlePage`. That runs for every anime sync page, before `checkSync` and independently of the mode. The tracking mode still decides *when the list gets updated*; it no longer decides whether the position is worth remembering.

The stored value is cleared when playback actually passes the completion threshold, rather than when the list is updated.

| | before | after |
|---|---|---|
| `instant` / `manual` | no position | remembered |
| episode already watched (`Nothing to Sync`) | no position | remembered |
| rewatch | no position | remembered |

New setting **Remember playback position**, on by default. **Auto resume** is now only shown when it is enabled, since it means nothing otherwise.

## Reader progress is untouched

Manga progress comes from `MangaStrategy` rather than from the player, so the new class takes progress through `report()` and the manga path keeps feeding it from `startSyncHandling`, with resume prompts off as they were. One behaviour difference: pressing the sync button early no longer discards the stored chapter position. That follows from clearing on completion rather than on sync, and seemed more useful than the old behaviour, but say the word if you would rather keep it as it was.

## A dropped seek no longer loses the offer

`setTime` posts a message to the player frame and gets nothing back. It is silently dropped when that frame has no player yet — which is exactly the case before playback has been started. The prompt used to close on click regardless, leaving no way to retry:

```
M Resume Resume to 84.99
[Iframe] Set Time {time: 84.99}
[Iframe] No player Found      <- and the prompt was already gone
```

It now stays until the player is actually observed at the requested position, and after a short delay a hint appears telling the user to start the video and click again. Confirmed on a real page: two clicks before playback do nothing and keep the offer, the click after pressing play lands and the prompt closes.

## Known limitation, not addressed here

`canSetTime()` returns true as soon as *any* frame has reported a player, while `videoTimeSet` is broadcast to every frame. On a site that keeps several player iframes around, the message reaches frames that have no player and the seek can miss. Confirming by observation works around it; fixing it properly means targeting the frame in the message relay, which touches `messageHandler` and the protocol with `iframe.ts`. That deserves its own change.

## Checked

- `npm run lint:ci` clean
- `npm run test:ts:ci` — 662 passing
- exercised in the browser on an unpacked build, in `instant` and in `video`, including the resume prompt, the dropped-seek path and the progress bar

## On the shape

This is the most intrusive change of the ones I have open — it touches `syncPage.ts` and changes a default. You had not replied on #4102, so I picked the direction described there rather than waiting. If you would rather have it as a sub-setting under `Instant`, or keep the position inside the tracking modes, I am happy to restructure — the behaviour and the plumbing are separable.
