### PR TITLE
chore: declare cheerio as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@vue/compiler-sfc": "^3.5.39",
         "archiver": "^8.0.0",
         "chai": "^6.2.2",
+        "cheerio": "^1.2.0",
         "chrome-webstore-upload": "^4.0.4",
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vue/compiler-sfc": "^3.5.39",
     "archiver": "^8.0.0",
     "chai": "^6.2.2",
+    "cheerio": "^1.2.0",
     "chrome-webstore-upload": "^4.0.4",
     "cross-env": "^7.0.3",
     "css-loader": "^7.1.4",


### PR DESCRIPTION
`webpackConfig/autoUrls.mjs` imports cheerio directly and uses it in three of the scrapers:

```js
import * as cheerio from 'cheerio';
...
const $ = cheerio.load(body);   // kickassanime, miruro, anikoto
```

but it is not declared anywhere. It only resolves because something else in the tree pulls it in, so a dependency bump could remove it and break the nightly autoUrls job with no warning — and the failure would look unrelated to whatever caused it.

The lockfile already contains the package, so declaring it only marks it as a direct dev dependency. Two lines, no version change, nothing new to download.

This was the second commit of #4096. You closed that in favour of #4105, which removed `to-string-loader` and made the npm 12 part unnecessary — a better fix than mine. This half is unrelated to that though, so here it is on its own.
