### PR TITLE
Add new URL for vidmoly player from voiranime

### DIFF
--- a/src/pages/diffUrls.json
+++ b/src/pages/diffUrls.json
@@ -146,6 +146,7 @@
     "iframe": [
       "*://*.miixdrop.com/e/*",
       "*://playmogo.com/e/*",
+      "*://voembed.net/*",
       "*://matthewhotelscience.com/e/*",
       "*://jessicachoosemake.com/e/*",
       "*://stevenfamilyedge.com/e/*",

--- a/src/pages/playerUrls.js
+++ b/src/pages/playerUrls.js
@@ -422,6 +422,7 @@ module.exports = {
       '*://vidmoly.to/*',
       '*://vidmoly.net/*',
       '*://vidmoly.biz/*',
+      '*://voembed.net/*',
       // auto-vidmoly-replace-dont-remove
     ],
   },


### PR DESCRIPTION
Default player for voiranime is no longer detected. See https://voir-anime.to/anime/mushoku-tensei-3/mushoku-tensei-3-07-vostfr/ for example. It appears to use the domain voembed.net which seems to be a mirror of vidmoly.biz (not a replacement: vidmoly.biz is not redirecting to this domain).