### PR TITLE
[Bug Fix] Fix search and URL matching for RoliaScan with updated tests

### DIFF
--- a/src/pages-chibi/implementations/RoliaScan/main.ts
+++ b/src/pages-chibi/implementations/RoliaScan/main.ts
@@ -28,11 +28,11 @@ export const RoliaScan: PageInterface = {
     readerConfig: [
       {
         current: {
-          selector: '.manga-child-the-content img',
+          selector: '.comic-image',
           mode: 'countAbove',
         },
         total: {
-          selector: '.manga-child-the-content img',
+          selector: '.comic-image',
           mode: 'count',
         },
       },

--- a/src/pages-chibi/implementations/RoliaScan/main.ts
+++ b/src/pages-chibi/implementations/RoliaScan/main.ts
@@ -8,9 +8,10 @@ export const RoliaScan: PageInterface = {
   urls: {
     match: ['*://roliascan.com/*'],
   },
+  search: 'https://roliascan.com/browse/?title={searchtermRaw}',
   sync: {
     isSyncPage($c) {
-      return $c.url().urlPart(5).matches('chapter[_-]').run();
+      return $c.url().urlPart(3).equals('read').run();
     },
     getTitle($c) {
       return $c.url().urlPart(4).replaceAll('-', ' ').run();
@@ -22,12 +23,18 @@ export const RoliaScan: PageInterface = {
       return $c.string('/manga/').concat($c.this('sync.getIdentifier').run()).urlAbsolute().run();
     },
     getEpisode($c) {
-      return $c.url().urlPart(5).regex('chapter[_-](\\d+)', 1).number().run();
+      return $c.url().urlPart(5).regex('^ch0*(\\d+)', 1).number().run();
     },
     readerConfig: [
       {
-        current: $c => $c.querySelectorAll('.manga-child-the-content img').countAbove().run(),
-        total: $c => $c.querySelectorAll('.manga-child-the-content img').length().run(),
+        current: {
+          selector: '.manga-child-the-content img',
+          mode: 'countAbove',
+        },
+        total: {
+          selector: '.manga-child-the-content img',
+          mode: 'count',
+        },
       },
     ],
   },

--- a/src/pages-chibi/implementations/RoliaScan/main.ts
+++ b/src/pages-chibi/implementations/RoliaScan/main.ts
@@ -11,7 +11,12 @@ export const RoliaScan: PageInterface = {
   search: 'https://roliascan.com/browse/?title={searchtermRaw}',
   sync: {
     isSyncPage($c) {
-      return $c.url().urlPart(3).equals('read').run();
+      return $c
+        .and(
+          $c.url().urlPart(3).equals('read').run(),
+          $c.url().urlPart(5).matches('^ch\\d').run(),
+        )
+        .run();
     },
     getTitle($c) {
       return $c.url().urlPart(4).replaceAll('-', ' ').run();
@@ -27,14 +32,8 @@ export const RoliaScan: PageInterface = {
     },
     readerConfig: [
       {
-        current: {
-          selector: '.comic-image',
-          mode: 'countAbove',
-        },
-        total: {
-          selector: '.comic-image',
-          mode: 'count',
-        },
+        current: $c => $c.querySelectorAll('.comic-image').countAbove().run(),
+        total: $c => $c.querySelectorAll('.comic-image').length().run(),
       },
     ],
   },

--- a/src/pages-chibi/implementations/RoliaScan/main.ts
+++ b/src/pages-chibi/implementations/RoliaScan/main.ts
@@ -12,10 +12,7 @@ export const RoliaScan: PageInterface = {
   sync: {
     isSyncPage($c) {
       return $c
-        .and(
-          $c.url().urlPart(3).equals('read').run(),
-          $c.url().urlPart(5).matches('^ch\\d').run(),
-        )
+        .and($c.url().urlPart(3).equals('read').run(), $c.url().urlPart(5).matches('^ch\\d').run())
         .run();
     },
     getTitle($c) {

--- a/src/pages-chibi/implementations/RoliaScan/tests.json
+++ b/src/pages-chibi/implementations/RoliaScan/tests.json
@@ -3,34 +3,67 @@
   "url": "https://roliascan.com",
   "testCases": [
     {
-      "url": "https://roliascan.com/manga/gosu/chapter-232_-s2-145/",
+      "url": "https://roliascan.com/read/kingdom/ch1-31634/",
       "expected": {
         "sync": true,
-        "title": "gosu",
-        "identifier": "gosu",
-        "overviewUrl": "https://roliascan.com/manga/gosu",
-        "episode": 232,
+        "title": "kingdom",
+        "identifier": "kingdom",
+        "overviewUrl": "https://roliascan.com/manga/kingdom",
+        "episode": 1,
         "uiSelector": false
       }
     },
     {
-      "url": "https://roliascan.com/manga/study-group/chapter-234-5-s2-epilogue/",
+      "url": "https://roliascan.com/read/kingdom/ch52-1-31686/",
       "expected": {
         "sync": true,
-        "title": "study group",
-        "identifier": "study-group",
-        "overviewUrl": "https://roliascan.com/manga/study-group",
-        "episode": 234,
+        "title": "kingdom",
+        "identifier": "kingdom",
+        "overviewUrl": "https://roliascan.com/manga/kingdom",
+        "episode": 52,
         "uiSelector": false
       }
     },
     {
-      "url": "https://roliascan.com/manga/hero-killer/",
+      "url": "https://roliascan.com/read/yongbi/ch32-79157/",
+      "expected": {
+        "sync": true,
+        "title": "yongbi",
+        "identifier": "yongbi",
+        "overviewUrl": "https://roliascan.com/manga/yongbi",
+        "episode": 32,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://roliascan.com/read/eleceed/ch001-17457/",
+      "expected": {
+        "sync": true,
+        "title": "eleceed",
+        "identifier": "eleceed",
+        "overviewUrl": "https://roliascan.com/manga/eleceed",
+        "episode": 1,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://roliascan.com/read/eleceed/ch12-17468/",
+      "expected": {
+        "sync": true,
+        "title": "eleceed",
+        "identifier": "eleceed",
+        "overviewUrl": "https://roliascan.com/manga/eleceed",
+        "episode": 12,
+        "uiSelector": false
+      }
+    },
+    {
+      "url": "https://roliascan.com/manga/kingdom/",
       "expected": {
         "sync": false,
-        "title": "hero killer",
-        "identifier": "hero-killer",
-        "image": "https://roliascan.com/wp-content/uploads/2024/11/xll1.jpg",
+        "title": "kingdom",
+        "identifier": "kingdom",
+        "image": "https://roliascan.com/content/media/manga-10610-cover-1775133365.jpg",
         "uiSelector": true
       }
     }

--- a/src/pages-chibi/implementations/RoliaScan/tests.json
+++ b/src/pages-chibi/implementations/RoliaScan/tests.json
@@ -58,6 +58,17 @@
       }
     },
     {
+      "url": "https://roliascan.com/read/study-group/ch1-58344/",
+      "expected": {
+        "sync": true,
+        "title": "study group",
+        "identifier": "study-group",
+        "overviewUrl": "https://roliascan.com/manga/study-group",
+        "episode": 1,
+        "uiSelector": false
+      }
+    },
+    {
       "url": "https://roliascan.com/manga/kingdom/",
       "expected": {
         "sync": false,


### PR DESCRIPTION
##  Changes

RoliaScan's live site has moved off the URL scheme this source was originally written
against. Chapter pages used to live at /manga/{slug}/chapter-N/, they're now at
/read/{slug}/chN-id/. The old pattern 404s on the current site, so isSyncPage never
matched and the extension popup never appeared on chapter pages.

- sync.isSyncPage: now checks urlPart(3) === 'read' instead of matching chapter[_-] on
  a segment that no longer contains that word.
- sync.getEpisode: chapter URLs look like ch1-31634 (whole chapters) or ch52-1-31686
  (fractional chapters, e.g. omake/extra numbered 52.1). Since MAL's progress field is
  integer only, fractional chapters are floored to their whole number part rather than
  attempting to preserve the decimal. New regex: ^ch0*(\d+), which also transparently
  handles the site's inconsistent zero padding (ch001-... vs ch12-... for the same
  title, confirmed on Eleceed's chapter list).
- sync.readerConfig: the old .manga-child-the-content img selector matched zero
  elements on the live site. Confirmed via devtools that page images now use the class
  .comic-image instead, and that the element count matches the actual page total.
  Updated both current and total selectors accordingly.
- search: added, using https://roliascan.com/browse/?title={searchtermRaw}, manually
  verified against the live site.
- sync.getTitle, getIdentifier, getOverviewUrl, and the overview block: unchanged, the
  /manga/{slug}/ overview URL structure and the identifier's position in the URL were
  not affected by the migration.
- Test fixture replaced: the old cases used pre migration URLs
  (/manga/gosu/chapter-232_-s2-145/) that now 404. New cases use real, currently live
  URLs (Kingdom, Yongbi, Eleceed) covering whole chapters, a fractional chapter, and
  both padding styles.

## Testing

Verified manually against the live, logged in site for:
- Chapter and overview URL structure, and the og:image/h1 selectors (Kingdom, Gosu
  overview pages)
- Whole number and fractional chapter URL formats (Kingdom ch1, ch52-1)
- Inconsistent chapter number padding (Eleceed ch001 vs ch12)
- The /browse/?title= search endpoint
- The .comic-image reader selector, confirmed the querySelectorAll count matches the
  actual page count in the reader UI